### PR TITLE
Updating the serial page in Triton tutorials

### DIFF
--- a/triton/tut/serial.rst
+++ b/triton/tut/serial.rst
@@ -136,8 +136,8 @@ Examples include partitions assigned to debugging("debug" partition),
 batch processing("batch" partition), GPUs("gpu" partition), etc.
 
 Command ``sinfo`` lists the available partitions. Let's see the first 4 partitions listed
-for the sake of brevity. 
-::
+for the sake of brevity::
+
    $ sinfo | head -n 5
    PARTITION     AVAIL  TIMELIMIT  NODES  STATE NODELIST
    interactive      up 1-00:00:00      2   drng pe[1-2]

--- a/triton/tut/serial.rst
+++ b/triton/tut/serial.rst
@@ -45,10 +45,10 @@ Let's take a look at the following script
    #!/bin/bash
    #SBATCH --time=00:05:00    
    #SBATCH --mem-per-cpu=100  
-   #SBATCH --output=result.out
+   #SBATCH --output=/scratch/work/%u/hello.%j.out
    #SBATCH --partition debug
 
-   srun echo "Hello ${USER}! You are on ${HOSTNAME}"
+   srun echo "Hello ${USER}! You are on node ${HOSTNAME}"
 
 Let's name it ``hello.sh`` (create a file using your editor of choice, e.g.nano; 
 write the script above and save it)
@@ -80,8 +80,8 @@ You can check the status of you jobs using ``slurm q``
    52428672           debug     hello.sh              0:00              N/A  PENDING (None)
 
 Once the job is completed successfully, the state changes to *COMPLETED* and the 
-output is then saved to ``result.out`` in your current
-directory (the number being the job ID).
+output is then saved to ``hello.%j.out`` in your work
+directory ("%j" is replaced by the jobID).
 
 Setting resource parameters
 ===========================

--- a/triton/tut/serial.rst
+++ b/triton/tut/serial.rst
@@ -2,195 +2,195 @@
 Serial Jobs
 ===========
 
+
+Introduction to batch scripts
+=============================
+
+You learned, in the :doc:`interactive jobs <interactive>` 
+how all Triton users must do their computation by submitting jobs
+to the Slurm batch system to ensure efficient resource sharing. 
+
+You additionally learned the interactive way to submit jobs,
+e.g. you could simply have an interative Bash session on a
+compute node. This proves useful for tests and debugging.
+Slurm jobs, however, are normally batch jobs, meaning that
+they are run unattended and asynchronously, without human 
+supervision. 
+
+To create a batch job, you need to create a job script and subsequently
+submit it to Slurm. A job script is simply a **shell script**, 
+e.g. Bash, where you put your **resource requests** and **job steps**. 
+You will see what these two components are shortly.
+You have already seen how to do these interactively; and in this tutorial
+you will learn how to bundle them in your job scripts.
+
 .. seealso::
 
-   This assumes you have read :doc:`the interactive jobs tutorial
-   <interactive>` first.
+   Please refer to the :doc:`interactive jobs
+   <interactive>` tutorial to learn the basics
+   of Slurm.
 
-Introduction
-============
+Your first job script
+=====================
 
-Triton is a large system that combines many different individual
-computers. At the same time, hundreds of people are using it. Thus, we
-must use a batch queuing system (slurm) in order to allocate resources.
+A job script is simply a shell script (Bash). And so the first line
+in the script should be the `shebang <https://en.wikipedia.org/wiki/Shebang_(Unix)>`_ directive (``#!``) followed by the
+full path to the executable binary of the shell's interpreter, which is 
+Bash in our case. What then follow are the resource requests and the job steps.
 
-The queue system takes computation requests from everyone, figures out
-the optimal use of resources, and allocates code to nodes. You have to
-start your code in a structured way in order for this to work. Our
-:doc:`previous tutorial <interactive>` showed how to
-run things directly from the command line, without any scripting needed.
+Let's take a look at the following script 
 
-Now let's see how to put these into scripts.  A **shell script** takes
-any commands that you might type directly into a shell and automates
-them.  The **slurm scripts** that we make in this lesson do do this.
-Scripts allow jobs to run asynchronously, in batch, and without human
-supervision.
+.. code-block:: bash
 
+   #!/bin/bash
+   #SBATCH --time=00:05:00    
+   #SBATCH --mem-per-cpu=100  
+   #SBATCH --output=result.out
+   #SBATCH --partition debug
 
+   srun echo "Hello ${USER}! You are on ${HOSTNAME}"
 
-A basic script
-==============
+Let's name it ``hello.sh`` (create a file using your editor of choice, e.g.nano; 
+write the script above and save it)
 
-Let's say we want to run ``echo 'hello world'``. We have to tell the
-system how to run it.  Here is a simple submission script, put it in a
-file called ``hello.slrm`` (you can use the editor nano: ``nano
-hello.slrm``)::
+The symbol ``#`` followed by the *SBATCH* directives are understood 
+by Slurm as parameters, determining the resource requests. 
+Here, we have requested a time limit of 5 minutes, along with 100 MB of RAM per CPU.
 
-    #!/bin/bash
-    #SBATCH --time=0-00:05:00    # 5 mins
-    #SBATCH --mem-per-cpu=500    # 500MB of memory
+Resource requests are followed by job steps, which are the actual
+tasks to be done. Each ``srun`` is a job step, and appears as a separate row in your
+history - which is useful for monitoring.
 
-    srun echo 'hello, world'
+Having written the script, you need to submit the job to Slum through the ``sbatch`` command
 
-**Whatever your application or programming language requires, you put
-it in the script.**
+::
 
-Each ``srun`` is a job step, and appears as a separate row in your
-history - which is useful for monitoring.  Then submit it with
-``sbatch``::
+   $ sbatch hello.sh
+   Submitted batch job 52428672
 
-    $ sbatch hello.slrm
+When the job enters the queue successfully, the response that the job has been submitted
+is printed in your terminal, along with the *job ID* assigned to the job. 
 
-.. warning:: You must use ``sbatch``, not ``bash`` to submit the job
-   to process the ``#SBATCH`` headers and run in the background.
+You can check the status of you jobs using ``slurm q``
 
-This sends it to the queue to wait. Since the time requested is short,
-it will probably run on the debug partition, which is reserved for small
-test jobs (see below). Let's see if it is in the queue:
+::
 
-Checking job status with ``slurm q``::
+   $ slurm q
+   JOBID              PARTITION NAME                  TIME       START_TIME    STATE NODELIST(REASON)
+   52428672           debug     hello.sh              0:00              N/A  PENDING (None)
 
-    $ slurm q
-    JOBID              PARTITION NAME                  TIME       START_TIME    STATE NODELIST(REASON)
-    13031249           debug     hello.slrm            0:00              N/A  PENDING (None)
-
-Keep rerunning ``slurm q`` until you see it finish.
-
-You can use ``scancel`` with that jobid to cancel the job before it
-finishes.
-
-The output is then saved to ``slurm-13031249.out`` in your current
+Once the job is completed successfully, the state changes to *COMPLETED* and the 
+output is then saved to ``result.out`` in your current
 directory (the number being the job ID).
 
+Setting resource parameters
+===========================
 
+In both the above example and the tutorial on :doc:`interactive jobs <interactive>`, you learned
+that resources are requested through job parameters such as ``--mem``, ``--time``, etc. 
 
-Loading modules in scripts
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. seealso::
 
-Need to load modules for your software?  Do it in the batch scripts.
-In general, anything you can do from the shell, you can do here::
+   See :doc:`interactive jobs <interactive>`, the :doc:`reference
+   page <../ref/index>` or the :doc:`details page
+   <../usage/general>` for more information and advanced usage.
 
-    #!/bin/bash
-    #SBATCH --time=0-00:05:00    # 5 mins
-    #SBATCH --mem-per-cpu=500    # 500MB of memory
+Please keep in mind that these parameters are hard values. If, for example, you request 5 GB of memory
+and your job uses substantially more, Slurm will kill your job. 
 
-    module load anaconda
-    python -V
+We recommend you be as specific as possible when setting your resource parameters
+as they determine how fast your jobs will run. 
+Therefore, please try to gain more understanding on how much resources your code needs
+to fine-tune your requested resources. 
 
-**Exercise**: Try the Python version-printing script above.  Try
-changing to different modules, ``anaconda2``, ``Python``, and others
-if you can find them.
+.. note::
 
+   In general, please do not submit too short jobs (under 5
+   minutes) unless you are debugging. For your bulk production, try to 
+   have each job take at least 30 minutes, if possible.
+   The reason behind this is that there is a big amount of startup, accounting, and scheduling overhead.
 
-
-Job parameters
-~~~~~~~~~~~~~~
-
-As you can see, the above script is limited to 5 minutes and 500MB of
-memory. All scripts have to have limits, otherwise they can't be
-efficiently scheduled. If you exceed the limits, the jobs will be
-killed. At least you need to set ``--time``, ``--mem-per-cpu`` or
-``--mem``.
-
-See the :doc:`previous tutorial <interactive>`, the :doc:`reference
-page <../ref/index>` or the :doc:`details page
-<../usage/general>` for more information and advanced usage.
-
-The same parameters can be used in
-
--  The sbatch script, prefixed by ``#SBATCH``
--  The ``sbatch`` command line program directly (like ``-p debug``
-   above)
--  ``sinteractive``/``srun`` from the command line, which lets you run
-   programs without a batch script.
-
-It is important to note that slurm is a declarative system. You declare
-what you need, and slurm handles finding the resources without you
-having to worry about details. The more resources you request, the
-harder it will be to schedule and the longer you may have to wait. So,
-you should ask for enough to make sure your job can complete, but once
-you get experience with your code reduce resources to just what is needed.
-
-In general, you don't want to go submitting too short jobs (under 5
-minutes) because there is a lot of startup, accounting, and scheduling
-overhead. If you are testing, short things are fine, but once you get to
-bulk production try to have each job take at least 30 minutes if
-possible. If you have lots of things to run, combine them into fewer
-jobs.
-
-
-
-Full slurm reference
+Monitoring your jobs
 ====================
 
-.. include:: ../ref/slurm.rst
+Once you submit your jobs, it goes into a queue. The two most useful commands to see
+the status of your jobs with are ``slurm q`` and ``slurm h`` (You've seen both in use).
 
+For example, command ``scontrol show -d jobid <jobid>`` provides you detailed information
+on a job. Information such as where *stderr* and *stdout* will be redirected to. These information
+can be particularly beneficial for troubleshooting.
 
-Status of the jobs
-==================
+Another example could be the command ``sacct --format=jobid,elapsed,ncpus,ntasks,state,MaxRss``
+which will show information as indicated in the ``--format`` option (job ID, the elapsed time,
+number of occupied CPUs, etc.). You can specify any field of interest to be shown using ``--format``.
 
-Once you submit jobs, it goes into a queue. You need to be able to see
-the status of jobs. There are commands to do this.
-
-+--------------------------------------+--------------------------------------+
-| Command                              |                                      |
-+======================================+======================================+
-| slurm j <jobid>                      | Status on single job (still running) |
-+--------------------------------------+--------------------------------------+
-| slurm history [2hours\|5days\|...]   | Info on completed jobs, including    |
-|                                      | mem/cpu usage.                       |
-+--------------------------------------+--------------------------------------+
+You can see more commands below. 
 
 .. include:: ../ref/slurm_status.rst
-
-See the full list of status commands on the :doc:`reference page
-<../ref/index>`.
-
-
 
 Partitions
 ==========
 
-There are different *partitions*, which have different limits. The
-"debug" partition is for short debugging, so is designed to always be
-available. The "batch" partition is designed for all the normal long
-jobs. There are also partitions for GPUs, huge memory nodes, interactive
-shells, and so on. Most of the time, you should leave the partition off,
-and slurm will use all possible partitions. You can specify your
-partitions with ``-p PARTITION_NAME`` to whatever command you are
-running, which is mainly needed if you want to force interactive or a
-test partition. The available partitions are listed on the
-reference page.
+A partition is a set of computing nodes dedicated to a specific purpose.
+Examples include partitions assigned to debugging("debug" partition), 
+batch processing("batch" partition), GPUs("gpu" partition), etc.
 
-You can see the partitions in the :doc:`quick
-reference<../ref/index>`.
+Command ``sinfo`` lists the available partitions. Let's see the first 4 partitions listed
+for the sake of brevity. 
+::
+   $ sinfo | head -n 5
+   PARTITION     AVAIL  TIMELIMIT  NODES  STATE NODELIST
+   interactive      up 1-00:00:00      2   drng pe[1-2]
+   jupyter-long     up 10-00:00:0      2   drng pe[1-2]
+   jupyter-short    up 1-00:00:00      2   drng pe[1-2]
+   grid             up 3-00:00:00      1  drain pe76
+
+You can specify a partition to be listed by ``sinfo``
+
+::
+   $ sinfo --partition=debug
+   PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
+   debug        up    1:00:00      1 drain* wsm1
+   debug        up    1:00:00      1  drain pe3
+   debug        up    1:00:00      1   idle pe83
+
+Take a look at the manpage using ``man sinfo`` for more details. 
+
+Generally, you don't need to specify the partition; Slurm will
+use any posssible partition. However, you can do so with ``-p PARTITION_NAME``
+This is mainly needed if you want to force interactive or
+debug partition (Slurm usually runs short jobs on the debug partition).
+
+.. seealso::
+
+   You can see the partitions in the :doc:`quick
+   reference<../ref/index>`.
+
+Full reference
+==============
+.. include:: ../ref/slurm.rst
+
+.. seealso::
+
+   There is a full description of `running jobs on
+   Triton <../usage/general>`, and the `reference
+   page <../ref/index>` lists many useful commands.
 
 Exercises
 =========
 
-1. Basics
+1. Submit a batch job that just runs ``hostname``.
 
-   a. Submit a batch job that just runs ``hostname``.
-   b. Set time to 1 hour and 15 minutes, memory to 500MB.
-   c. Change the job's name and output file.
-   d. Monitor the job with ``slurm watch queue``.
-   e. Check the output.  Does it match ``slurm history``?
+   a. Set time to 1 hour and 15 minutes, memory to 500MB.
+   b. Change the job's name and output file.
+   c. Monitor the job with ``slurm watch queue``.
+   d. Check the output.  Does it match ``slurm history``?
 
 2. Create a simple batch script using ``pi.py`` based on the pi
    calculation of the :doc:`interactive job tutorial exercises
    <interactive>`.  Create multiple job steps (separate ``srun``
    lines), each of which runs ``pi.py`` with a greater and greater
-   number of tries.  How does this appear in ``slurm history``.  When
+   number of tries.  How does this appear in ``slurm history``?  When
    would you use extra ``srun`` commands, and when not?
 
 3. Create a batch script which does nothing (or some pointless
@@ -205,14 +205,8 @@ Exercises
 4. (Advanced) Create a batch script that runs in another language.
    Does it run?  What are some of the advantages and problems here?
 
-
-Next steps
-==========
-
-There is a full description of `running jobs on
-Triton <../usage/general>`, and the `reference
-page <../ref/index>` lists many useful commands.
+What's next?
+============
 
 Running multiple instances of a ``sbatch`` script is easier with
-:doc:`array jobs<../tut/array>`.
-
+:doc:`array jobs<../tut/array>`. 


### PR DESCRIPTION
I updated the text and reorganized the sections. Some extra examples of Slurm commands are added.
There are a few to-dos I'd like your input on. 

- I'd like to add some more structured rules of thumb about setting resource parameters (more specific details on how long/large jobs should be).
- Is the reference page on partitions updated (partitions, number of nodes, etc.)?
- I'd additionally like to write a simple code sample (just as in `interactive.rst`) that require some logging and I/O.

There will be further synchronization between the `Interactive jobs`, `Serial jobs`, and `Array jobs`. 
