### PR TITLE
Updating the array jobs page in Triton tutorials

### DIFF
--- a/triton/tut/array.rst
+++ b/triton/tut/array.rst
@@ -9,7 +9,7 @@ where there is no dependency or communication among the processes.
 Their results are thus combined as the final output, e.g. Monte Carlo simulations.
 
 In Slurm context, *job arrays* are the way to run several instances of a 
-single-threaded program, known as *embarassingly parallel* paradigm. 
+single-threaded program, known as the *embarrassingly parallel* paradigm. 
 
 Introduction
 ============
@@ -52,7 +52,7 @@ as you wish. Let's name it ``hello.sh`` and write it as follows.
    #SBATCH --array=0-15
    #SBATCH --time=00:15:00
    #SBATCH --mem=200
-   # You may put the commands after SBATCH directives
+   # You may put the commands below:
    
    # Job step
    srun echo "I am array task number" $SLURM_ARRAY_TASK_ID
@@ -64,7 +64,7 @@ Submitting the job script to Slurm with ``sbatch hello.sh``, you will get the me
   $ Submitted batch job 52608925
 
 The job ID in the message is that of the "master" job - which is also used in the 
-batch script using ``%A`` for the output files. To create unique output files for 
+batch script using ``%A`` for the output files (with the slurm ``-o`` option). To create unique output files for 
 each task in the job array, ``%a`` is used that is filled in with the array task ID.
 
 Once the jobs are completed, the output files will be created in your work directory,

--- a/triton/tut/array.rst
+++ b/triton/tut/array.rst
@@ -295,7 +295,7 @@ Exercises
 What's next?
 ============
 
-.. see-also::
+.. seealso::
    
    For more information, you can see the
    `CSC guide on array jobs <https://docs.csc.fi/computing/running/array-jobs/>`_

--- a/triton/tut/array.rst
+++ b/triton/tut/array.rst
@@ -4,34 +4,111 @@ Array jobs
 
 .. highlight:: bash
 
+More often than not, problems involve running similar programs in parallel 
+where there is no dependency or communication among the processes.
+Their results are thus combined as the final output, e.g. Monte Carlo simulations.
+
+In Slurm context, *job arrays* are the way to run several instances of a 
+single-threaded program, known as *embarassingly parallel* paradigm. 
+
 Introduction
 ============
 
-By now, you should be able to do all the basic things to run programs on
-Triton. Now, you want to do it... a lot. The easiest way to parallize
-things is to use array jobs. With array jobs, you take a single code or
-script, and Slurm (the batch system) runs it many times for you, with
-all the parameters. This is the simplest way of parallelizing things,
-but only works for *embarrasingly parallel* problems: where your code
-runs independently multiple times, and you use or combine the results
-later. Still, for most people, this is as far as you need to go.
+Array jobs allow you to parallelize your computations. They are used when you need
+to run the same job many times with only slight changes among the jobs. For example,
+you need to run 1000 jobs each with a different seed value for the random number generator.
+Or perhaps you need to apply the same computation to a collection of data sets. 
+These can be done by submitting a single array job.
 
-Basic examples
-==============
+Slurm job array is a collection of jobs that are to be executed with identical
+parameters. This means that there is one single batch script that is to be run
+as many times as indicated by the ``--array`` directive, e.g.,
 
-When you run an array job (with ``--array=1-5``), Slurm runs your job
-script many (5) times, with
-one difference: the environment variable ``SLURM_ARRAY_TASK_ID``
-(1,2,3,4,5). You have your job script or code read this variable and take
-the right action, depending on what you need to do.
+::
 
-Below are four examples.  The first and third are probably most
-recommended for starting out.
+  #SBATCH --array=0-4
 
-Different inputs
-~~~~~~~~~~~~~~~~
+creates an array of 5 jobs (tasks) with index values 0, 1, 2, 3, 4. 
 
-In the example below, the ``$SLURM_ARRAY_TASK_ID`` is used to change to
+The array tasks are copies of the "master" batch script that are automatically submitted
+to Slurm. Slurm provides a unique environment variable ``SLURM_ARRAY_TASK_ID`` to each
+task which could be used for handling input output files to each task. 
+
+.. note:: 
+
+   You can alternatively pass the ``--array`` option as a command-line argument to
+   ``sbatch``.
+
+Your first array job
+====================
+
+Let's see a job array in action. Create a file with your favorite editor and name it
+as you wish. Let's name it ``hello.sh`` and write it as follows.
+
+.. code-block:: bash
+
+   #SBATCH --job-name=slurm_env_var
+   #SBATCH --output=/scratch/work/%u/task_number_%A_%a.out
+   #SBATCH --array=0-15
+   #SBATCH --time=00:15:00
+   #SBATCH --mem=200
+   # You may put the commands after SBATCH directives
+   
+   # Job step
+   srun echo "I am array task number" $SLURM_ARRAY_TASK_ID
+  
+Submitting the job script to Slurm with ``sbatch hello.sh``, you will get the message
+
+::
+
+  $ Submitted batch job 52608925
+
+The job ID in the message is that of the "master" job - which is also used in the 
+batch script using ``%A`` for the output files. To create unique output files for 
+each task in the job array, ``%a`` is used that is filled in with the array task ID.
+
+Once the jobs are completed, the output files will be created in your work directory,
+with the help ``%u`` to determine your user name. 
+
+::
+
+   $ ls $WRKDIR
+   task_number_52608925_12.out  task_number_52608925_3.out   task_number_52608925_8.out  task_number_52608925_9.out
+   task_number_52608925_0.out   task_number_52608925_13.out  task_number_52608925_4.out  
+   task_number_52608925_1.out   task_number_52608925_14.out  task_number_52608925_5.out
+   task_number_52608925_10.out  task_number_52608925_15.out  task_number_52608925_6.out
+   task_number_52608925_11.out  task_number_52608925_2.out   task_number_52608925_7.out
+
+You can ``cat`` one of the files to see the output of each task
+
+::
+
+   $ cat task_number_52608925_5.out
+   I am array task number 5
+
+.. important::
+
+   If your current directory is your home directory, please remember to direct 
+   your results to your work directory. You can keep your scripts/source codes
+   in you home directory since it is backed up daily and should keep your calculations
+   and analyses on your work directory. 
+
+More examples
+=============
+
+The following examples give you an idea on how to use job arrays for different
+use cases and how to utilize the ``$SLURM_ARRAY_TASK_ID`` environment variable. 
+
+
+Reading input files
+-------------------
+
+In many cases, you would like to process several data files, that is, pass different
+input files to your code to be processed. This can be achieved by using 
+``$SLURM_ARRAY_TASK_ID`` envinronment variable.  
+
+You could utilize to process several data files. In this case,
+In the example below, the is used to change to
 the right directory, make the application read the correct input file,
 and to generate output in a unique directory. This script is submitted
 with ``sbatch script.sh``::
@@ -39,214 +116,193 @@ with ``sbatch script.sh``::
     #!/bin/bash
     #SBATCH -n 1
     #SBATCH -t 04:00:00
-    #SBATCH --mem-per-cpu=2500
+    #SBATCH --mem-per-cpu=1G
     #SBATCH --array=0-29
 
     # Each array task runs the same program, but with a different input file.
-    cd $SLURM_ARRAY_TASK_ID
-    srun echo I am number $SLURM_ARRAY_TASK_ID
     # e.g. srun ./my_application -input input_data_$SLURM_ARRAY_TASK_ID
-    cd ..
 
-Different parameters in script
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Hardcoding arguments in the batch script
+----------------------------------------
 
-In the example below, we have the same program, but different command
-line parameters. In this case, everything is hard coded in the bash
-script itself. You could also do this directly inside your program, and
-generate the parameters according to some algorithm. This can be really
-powerful: not only can you both hard code and generate with algorithm,
-but if you never edit already-run parameters, you have a single place
-where you can see everything that has been run before. (Personally, I
-always try to set up a system where parameters are defined in one place,
-code in another, and I can always know what has been run for each output
-by looking in just one place. If you are going to be configuring stuff
-by hand anyway, better to have it all together.)::
+One way to pass arguments to your code is by hardcoding them in the batch script 
+you want to submit to Slurm. 
 
-    #!/bin/bash
-    #SBATCH -n 1
-    #SBATCH -t 04:00:00
-    #SBATCH --mem-per-cpu=2500
-    #SBATCH --array=0-4
+Assume you would like to run the Pi estimation code for 5 different seed values, each
+for 2.5 million iterations. You could assign a seed value to each task in you job array
+and save each output to a file. Having calculated all estimations, you could take the 
+average of all the Pi values to arrive at a more accurate estimate. An example of such
+a batch script is as follows. 
 
-    case $SLURM_ARRAY_TASK_ID in
-        0) ARGS="-res 5 -arg 3" ;;
-        1) ARGS="-res 6 -arg 3" ;;
-        2) ARGS="-res 5 -arg 4" ;;
-        3) ARGS="-res 6 -arg 4" ;;
-        4) ARGS="-res 5 -arg 5" ;;
-    esac
+.. code-block:: bash
 
-    cd $SLURM_ARRAY_TASK_ID
-    srun I am doing $ARGS !
-    # e.g. python input.py $ARGS
-    cd ..
+   #!/bin/bash 
+   #SBATCH --job-name=pi_estimation
+   #SBATCH --output=/dev/null
+   #SBATCH --error=/dev/null
+   #SBATCH --array=0-4
+   #SBATCH --time=01:00:00
+   #SBATCH --mem=500
+   # You may put the commands after SBATCH directives
 
-Read parameters from file
-~~~~~~~~~~~~~~~~~~~~~~~~~
+   case $SLURM_ARRAY_TASK_ID in
 
-Now we do basically the same thing as above, but we have all of the
-parameters stored in another file ``arrayparams.txt``::
+       0)
+           SEED=123
+           ;;
+       1)  
+           SEED=38
+           ;;
+       2)  
+           SEED=22 
+           ;;
+       3) 
+           SEED=60 
+           ;; 
+       4) 
+           SEED=432 
+           ;;
+   esac
 
-  input_561 --opt1
-  input_418 --opt2
-  input_569 --opt1
+   python ~/trit_examples/pi.py 2500000 --seed=$SEED > pi_$SEED.json
 
-In our script, we use the ``sed`` program to read just one line from
-the file.  This is stored in the variable ``line``, and then we can
-use this however: in this case by using it as the parameters to the
-program.  Don't worry about how the ``sed`` command works - no one
-really knows, we just find it via a web search.  Note that the line
-numbers start at one, not zero!
+Save the script as e.g. ``run_pi.sh`` and submit to Slurm.
 
 ::
 
-    #!/bin/bash
-    #SBATCH -n 1
-    #SBATCH -t 04:00:00
-    #SBATCH --mem-per-cpu=2500
-    #SBATCH --array=1-3
+   $ sbatch run_pi.sh
+   Submitted batch job 52655434
 
-    n=$SLURM_ARRAY_TASK_ID                  # define n
-    line=`sed "${n}q;d" arrayparams.txt`    # get n:th line (1-indexed) of the file
-
-    # Do whatever with arrayparams.txt
-    srun echo I am doing $line
-    # e.g. srun ./my_program $line
-
-
-(advanced) Grouping runs together in bigger chunks
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Let's say your tasks are very short - only a few minutes.  This is
-still a bit short to use array jobs, because you will still have too
-much overhead in scheduling.  We want to try for 30 minutes and if
-possible more.  So, below is an example script that uses shell
-
-In the below script, we take a chunk size of 100.  Array #0 will run
-0-99, array #1 will run 100-199, etc.  The for loop handles the
-running.  Before each one runs, it uses ``test -s output_$i`` to see if
-the output filename ``output_$i`` exists: only run the task if it does
-not exist already (see ``man test`` to see other types of tests you
-can do).  This example starts using more advanced shell scripting,
-which might be worth learning.
+Once finished, 5 files will be created in your current directory each containing the
+Pi estimation; total number of iterations (sum of iteration per task); 
+and total number of successes). 
 
 ::
 
-   [... all the initial stuff from above]
+   $ cat pi_22.json
+   {"successes": 1963163, "pi_estimate": 3.1410608, "iterations": 2500000}
+
+Reading parameters from one file
+--------------------------------
+
+Another way to pass arguments to your code via script is to save the arguments
+to a file and have your script read the arguments from it. 
+
+Drawing on the previous example, let's assume you now want to run ``pi.py``
+with different iterations. You can create a file, say ``iterations.txt``
+and have all the values written to it, e.g.
+
+::
+
+   $ cat iterations.txt
+   100
+   1000
+   50000
+   1000000
+
+You can modify the previous script to have it read the ``iterations.txt``
+one line at a time and pass it on to ``pi.py``. Here, ``sed`` is used
+to get each line. Alternatively you can use any other command-line
+utility in its stead, e.g. ``awk``. Do not worry if you don't know 
+how ``sed`` works - Google search and ``man sed`` always help. 
+Also note that the line numbers start at 1, not 0.
+
+.. code-block:: bash
+
+    #!/bin/bash
+    #SBATCH -n 1
+    #SBATCH --output=/dev/null
+    #SBATCH --error=/dev/null
+    #SBATCH --array=1-4
+    #SBATCH --time=01:00:00
+    #SBATCH --mem=500
+
+    n=$SLURM_ARRAY_TASK_ID
+    iteration=`sed -n "${n} p" iterations.txt`      # Get n-th line (1-indexed) of the file
+    python ~/pi.py ${iteration} > pi_iter_${n}.json
+
+You can additionally do this procedure in a more complex way, e.g. read in multiple
+arguments from a csv file, etc.
+
+(Advanced) Grouping runs together in bigger chunks
+--------------------------------------------------
+If your jobs are many and too short - a few minutes -, 
+using array jobs may induce too much overhead in scheduling. 
+Or you may simply have too many runs and creating too many array
+jobs again is not recommended. 
+
+.. important:: 
+
+   A good target time for the array jobs would be approximately 30 minutes,
+   so please try to combine your tasks so that each job would at least take this long.
+
+The workaround is exploiting shell's capabilities. For example,
+assume you want to run the Pi script with 50 different seed values. 
+You could define a chunk size of 10 and 5 array jobs. Even with as
+little as 5 array jobs, you can run 50 simulations.
+
+This method demands for more knowledge of shell scripting which will
+definitely be worth your while. 
+
+.. code-block:: bash
+
+   #!/bin/bash
+   #SBATCH -n 1
+   #SBATCH --output=/dev/null
+   #SBATCH --error=/dev/null
+   #SBATCH --array=1-5
+   #SBATCH --time=01:00:00
+   #SBATCH --mem=500
+
+   # Define and create a new directory (and an intermediate one) in your work directory
+   DIRECTORY=/scratch/work/${USER}/pi_simulations_results/json_files
+   mkdir -p ${DIRECTORY}
 
    CHUNKSIZE=100
-   arrayID=$SLURM_ARRAY_TASK_ID
-   indexes=`seq $((arrayID * CHUNKSIZE)) $(((arrayID+1)*CHUNKSIZE - 1))`
+   n=$SLURM_ARRAY_TASK_ID
+   indexes=`seq $((n*CHUNKSIZE)) $(((n + 1)*CHUNKSIZE - 1))`
 
-   for i in $indexes ; do
-       if ! test -s output_$i ; then
-           run $i
-       fi
+   for i in $indexes
+   do
+       python ~/pi.py 1500000 --seed=$i > ${DIRECTORY}/pi_$i.json
    done
 
+.. important::
 
-
-2D sampling
-~~~~~~~~~~~
-
-Here is an example that lets you sample from a 2D array, with
-experiments and 10 replicas (but this might be approaching hackish, ask
-first if it makes sense to have them together)::
-
-    experiment=$(( $SLURM_ARRAY_TASK_ID / 10 ))
-    replica=$(( $SLURM_ARRAY_TASK_ID % 10 ))
-
-More control
-============
-
-You can specify the ``--array=`` option either in the script itself
-using the ``#SBATCH`` syntax, or on the command line to ``sbatch``. So, you can
-control what runs different ways. Let's say you have a fixed number of
-parameters: put that directly in the script. Or if you are just running
-replicas, run them from the command line as you need more. In any case,
-us the command line when things fail and you need to repeat only
-certain runs.
-
-You don't have to have the job script use the variable. You could
-directly pass it as a command line argument to your program, use it to
-pattern input files, or even have your own code access the process
-environment and get the variable.
-
-You can use ``%N``, like ``--array=1-100%10``, to limit number of jobs
-running at once.
-
-Note that arrays are *only* a feature of ``sbatch``. You can't use them
-directly from the command line with ``srun``: you have to make a batch
-script and submit with ``sbatch``.
-
-Hints
-=====
-
-The array indices need not be sequential. E.g. if you discover that
-after the above array job is finished, the job task id's 7 and 19
-failed, you can relaunch just those jobs with ``--array=7,19``. While the
-array job above is a set of serial jobs, parallel array jobs are
-possible. For more information, see the `Slurm job array
-documentation <https://slurm.schedmd.com/job_array.html>`__.
-
-How do you map from ``$SLURM_ARRAY_TASK_ID`` to the parameters of the
-job? There are different strategies
-
--  Have a lookup table in your code or another config file (bash example
-   in slurm script above)
--  Pre-create different input files
--  Programmatically generate the different configs in your code.
--  Don't have different config, just use them to run multiple replicas
-   of the same parameters. You increase the array ID until you have
-   enough statistics to get your result.
-
-You probably want to look at the slurm ``-o`` option to direct the script
-output to somewhere useful. See the ``sbatch`` manual page, ``-o``,
-``-e``, and ``--open-mode`` options. In the filenames, use ``%a`` for array
-index and ``%A`` (array jobs) for array jobid.  For normal jobs, use
-``%j`` for the jobid.  (If you use ``%j`` for array jobs, you get a
-different number even when things were started as part of the same
-array.  Maybe it's what you want).
-
-Array jobs have less overhead for accounting and scheduling, but you
-still want them to not be too short. 30 minutes is a good target time,
-so try to combine smaller tasks to fit that.
-
+   The array indices need not be sequential, e.g. if you discover that
+   after the array job is finished, the job task id's 2 and 5
+   failed, you can relaunch just those jobs with ``--array=2,5``.
+   In this case you can simply pass the ``--array`` option
+   as a command-line argument to ``sbatch``.
 
 Exercises
 =========
 
-1. Look at ``man sbatch`` and investigate the ``--array`` parameter.
+1. Using the ``pi.py`` example from the :doc:`interactive tutorial
+   <interactive>`, create a job array that calculates a combination
+   of different iterations and seed values. Average them all to arrive
+   at a more accurate Pi.
 
-2. Using the ``pi.py`` example from the :doc:`interactive tutorial
-   <interactive>`, make an array job that calculates pi 10 times.
-
-   a) The ``pi.py`` program takes an extra option: ``--seed=SEED``.
-      Use the array task ID as the seed.
-
-   b) Verify that the runs worked.  Average all values together to get
-      your more accurate pi.
-
-3. Using one of the techniques above, use ``memory-hog.py`` from the
+2. Using one of the techniques above, use ``memory-hog.py`` from the
    :doc:`interactive tutorial <interactive>`.  Make an array job that
    runs this with five different values of the memory (5M, 50M, 100M,
-   200M, 500M).  You have to use one of the techniques above.
+   200M, 500M).
 
-3. Make job array which runs every other index (like 1, 3, 5,
-   etc).  You'll have to look at the ``sbatch`` manual page.
+3. Make job array which runs every other index, e.g. the array can be
+   indexed as 1, 3, 5...(``sbatch`` manual page can be of help)
 
 
 What's next?
 ============
 
+.. see-also::
+   
+   For more information, you can see the
+   `CSC guide on array jobs <https://docs.csc.fi/computing/running/array-jobs/>`_
+
+   Please check the `quick reference <../ref/index>` when needed.
+
+   if you need more detailed information about running on Triton, see the main page
+   `Running programs on Triton <../usage/general>`.
+
 The next tutorial is about :doc:`GPU computing <gpu>`.
-
-For more information, you can see the CSC guide on array jobs:
-`https://research.csc.fi/taito-array-jobs. <https://docs.csc.fi/computing/running/array-jobs/>`_
-
-For more detailed information about running on Triton, see the main page
-`Running programs on Triton <../usage/general>`.
-
-Remember to check the `quick reference <../ref/index>` when needed.
-
-

--- a/triton/tut/serial.rst
+++ b/triton/tut/serial.rst
@@ -2,195 +2,195 @@
 Serial Jobs
 ===========
 
+
+Introduction to batch scripts
+=============================
+
+You learned, in the :doc:`interactive jobs <interactive>` 
+how all Triton users must do their computation by submitting jobs
+to the Slurm batch system to ensure efficient resource sharing. 
+
+You additionally learned the interactive way to submit jobs,
+e.g. you could simply have an interative Bash session on a
+compute node. This proves useful for tests and debugging.
+Slurm jobs, however, are normally batch jobs, meaning that
+they are run unattended and asynchronously, without human 
+supervision. 
+
+To create a batch job, you need to create a job script and subsequently
+submit it to Slurm. A job script is simply a **shell script**, 
+e.g. Bash, where you put your **resource requests** and **job steps**. 
+You will see what these two components are shortly.
+You have already seen how to do these interactively; and in this tutorial
+you will learn how to bundle them in your job scripts.
+
 .. seealso::
 
-   This assumes you have read :doc:`the interactive jobs tutorial
-   <interactive>` first.
+   Please refer to the :doc:`interactive jobs
+   <interactive>` tutorial to learn the basics
+   of Slurm.
 
-Introduction
-============
+Your first job script
+=====================
 
-Triton is a large system that combines many different individual
-computers. At the same time, hundreds of people are using it. Thus, we
-must use a batch queuing system (slurm) in order to allocate resources.
+A job script is simply a shell script (Bash). And so the first line
+in the script should be the `shebang <https://en.wikipedia.org/wiki/Shebang_(Unix)>`_ directive (``#!``) followed by the
+full path to the executable binary of the shell's interpreter, which is 
+Bash in our case. What then follow are the resource requests and the job steps.
 
-The queue system takes computation requests from everyone, figures out
-the optimal use of resources, and allocates code to nodes. You have to
-start your code in a structured way in order for this to work. Our
-:doc:`previous tutorial <interactive>` showed how to
-run things directly from the command line, without any scripting needed.
+Let's take a look at the following script 
 
-Now let's see how to put these into scripts.  A **shell script** takes
-any commands that you might type directly into a shell and automates
-them.  The **slurm scripts** that we make in this lesson do do this.
-Scripts allow jobs to run asynchronously, in batch, and without human
-supervision.
+.. code-block:: bash
 
+   #!/bin/bash
+   #SBATCH --time=00:05:00    
+   #SBATCH --mem-per-cpu=100  
+   #SBATCH --output=result.out
+   #SBATCH --partition debug
 
+   srun echo "Hello ${USER}! You are on ${HOSTNAME}"
 
-A basic script
-==============
+Let's name it ``hello.sh`` (create a file using your editor of choice, e.g.nano; 
+write the script above and save it)
 
-Let's say we want to run ``echo 'hello world'``. We have to tell the
-system how to run it.  Here is a simple submission script, put it in a
-file called ``hello.slrm`` (you can use the editor nano: ``nano
-hello.slrm``)::
+The symbol ``#`` followed by the *SBATCH* directives are understood 
+by Slurm as parameters, determining the resource requests. 
+Here, we have requested a time limit of 5 minutes, along with 100 MB of RAM per CPU.
 
-    #!/bin/bash
-    #SBATCH --time=0-00:05:00    # 5 mins
-    #SBATCH --mem-per-cpu=500    # 500MB of memory
+Resource requests are followed by job steps, which are the actual
+tasks to be done. Each ``srun`` is a job step, and appears as a separate row in your
+history - which is useful for monitoring.
 
-    srun echo 'hello, world'
+Having written the script, you need to submit the job to Slum through the ``sbatch`` command
 
-**Whatever your application or programming language requires, you put
-it in the script.**
+::
 
-Each ``srun`` is a job step, and appears as a separate row in your
-history - which is useful for monitoring.  Then submit it with
-``sbatch``::
+   $ sbatch hello.sh
+   Submitted batch job 52428672
 
-    $ sbatch hello.slrm
+When the job enters the queue successfully, the response that the job has been submitted
+is printed in your terminal, along with the *job ID* assigned to the job. 
 
-.. warning:: You must use ``sbatch``, not ``bash`` to submit the job
-   to process the ``#SBATCH`` headers and run in the background.
+You can check the status of you jobs using ``slurm q``
 
-This sends it to the queue to wait. Since the time requested is short,
-it will probably run on the debug partition, which is reserved for small
-test jobs (see below). Let's see if it is in the queue:
+::
 
-Checking job status with ``slurm q``::
+   $ slurm q
+   JOBID              PARTITION NAME                  TIME       START_TIME    STATE NODELIST(REASON)
+   52428672           debug     hello.sh              0:00              N/A  PENDING (None)
 
-    $ slurm q
-    JOBID              PARTITION NAME                  TIME       START_TIME    STATE NODELIST(REASON)
-    13031249           debug     hello.slrm            0:00              N/A  PENDING (None)
-
-Keep rerunning ``slurm q`` until you see it finish.
-
-You can use ``scancel`` with that jobid to cancel the job before it
-finishes.
-
-The output is then saved to ``slurm-13031249.out`` in your current
+Once the job is completed successfully, the state changes to *COMPLETED* and the 
+output is then saved to ``result.out`` in your current
 directory (the number being the job ID).
 
+Setting resource parameters
+===========================
 
+In both the above example and the tutorial on :doc:`interactive jobs <interactive>`, you learned
+that resources are requested through job parameters such as ``--mem``, ``--time``, etc. 
 
-Loading modules in scripts
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. seealso::
 
-Need to load modules for your software?  Do it in the batch scripts.
-In general, anything you can do from the shell, you can do here::
+   See :doc:`interactive jobs <interactive>`, the :doc:`reference
+   page <../ref/index>` or the :doc:`details page
+   <../usage/general>` for more information and advanced usage.
 
-    #!/bin/bash
-    #SBATCH --time=0-00:05:00    # 5 mins
-    #SBATCH --mem-per-cpu=500    # 500MB of memory
+Please keep in mind that these parameters are hard values. If, for example, you request 5 GB of memory
+and your job uses substantially more, Slurm will kill your job. 
 
-    module load anaconda
-    python -V
+We recommend you be as specific as possible when setting your resource parameters
+as they determine how fast your jobs will run. 
+Therefore, please try to gain more understanding on how much resources your code needs
+to fine-tune your requested resources. 
 
-**Exercise**: Try the Python version-printing script above.  Try
-changing to different modules, ``anaconda2``, ``Python``, and others
-if you can find them.
+.. note::
 
+   In general, please do not submit too short jobs (under 5
+   minutes) unless you are debugging. For your bulk production, try to 
+   have each job take at least 30 minutes, if possible.
+   The reason behind this is that there is a big amount of startup, accounting, and scheduling overhead.
 
-
-Job parameters
-~~~~~~~~~~~~~~
-
-As you can see, the above script is limited to 5 minutes and 500MB of
-memory. All scripts have to have limits, otherwise they can't be
-efficiently scheduled. If you exceed the limits, the jobs will be
-killed. At least you need to set ``--time``, ``--mem-per-cpu`` or
-``--mem``.
-
-See the :doc:`previous tutorial <interactive>`, the :doc:`reference
-page <../ref/index>` or the :doc:`details page
-<../usage/general>` for more information and advanced usage.
-
-The same parameters can be used in
-
--  The sbatch script, prefixed by ``#SBATCH``
--  The ``sbatch`` command line program directly (like ``-p debug``
-   above)
--  ``sinteractive``/``srun`` from the command line, which lets you run
-   programs without a batch script.
-
-It is important to note that slurm is a declarative system. You declare
-what you need, and slurm handles finding the resources without you
-having to worry about details. The more resources you request, the
-harder it will be to schedule and the longer you may have to wait. So,
-you should ask for enough to make sure your job can complete, but once
-you get experience with your code reduce resources to just what is needed.
-
-In general, you don't want to go submitting too short jobs (under 5
-minutes) because there is a lot of startup, accounting, and scheduling
-overhead. If you are testing, short things are fine, but once you get to
-bulk production try to have each job take at least 30 minutes if
-possible. If you have lots of things to run, combine them into fewer
-jobs.
-
-
-
-Full slurm reference
+Monitoring your jobs
 ====================
 
-.. include:: ../ref/slurm.rst
+Once you submit your jobs, it goes into a queue. The two most useful commands to see
+the status of your jobs with are ``slurm q`` and ``slurm h`` (You've seen both in use).
 
+For example, command ``scontrol show -d jobid <jobid>`` provides you detailed information
+on a job. Information such as where *stderr* and *stdout* will be redirected to. These information
+can be particularly beneficial for troubleshooting.
 
-Status of the jobs
-==================
+Another example could be the command ``sacct --format=jobid,elapsed,ncpus,ntasks,state,MaxRss``
+which will show information as indicated in the ``--format`` option (job ID, the elapsed time,
+number of occupied CPUs, etc.). You can specify any field of interest to be shown using ``--format``.
 
-Once you submit jobs, it goes into a queue. You need to be able to see
-the status of jobs. There are commands to do this.
-
-+--------------------------------------+--------------------------------------+
-| Command                              |                                      |
-+======================================+======================================+
-| slurm j <jobid>                      | Status on single job (still running) |
-+--------------------------------------+--------------------------------------+
-| slurm history [2hours\|5days\|...]   | Info on completed jobs, including    |
-|                                      | mem/cpu usage.                       |
-+--------------------------------------+--------------------------------------+
+You can see more commands below. 
 
 .. include:: ../ref/slurm_status.rst
-
-See the full list of status commands on the :doc:`reference page
-<../ref/index>`.
-
-
 
 Partitions
 ==========
 
-There are different *partitions*, which have different limits. The
-"debug" partition is for short debugging, so is designed to always be
-available. The "batch" partition is designed for all the normal long
-jobs. There are also partitions for GPUs, huge memory nodes, interactive
-shells, and so on. Most of the time, you should leave the partition off,
-and slurm will use all possible partitions. You can specify your
-partitions with ``-p PARTITION_NAME`` to whatever command you are
-running, which is mainly needed if you want to force interactive or a
-test partition. The available partitions are listed on the
-reference page.
+A partition is a set of computing nodes dedicated to a specific purpose.
+Examples include partitions assigned to debugging("debug" partition), 
+batch processing("batch" partition), GPUs("gpu" partition), etc.
 
-You can see the partitions in the :doc:`quick
-reference<../ref/index>`.
+Command ``sinfo`` lists the available partitions. Let's see the first 4 partitions listed
+for the sake of brevity. 
+::
+   $ sinfo | head -n 5
+   PARTITION     AVAIL  TIMELIMIT  NODES  STATE NODELIST
+   interactive      up 1-00:00:00      2   drng pe[1-2]
+   jupyter-long     up 10-00:00:0      2   drng pe[1-2]
+   jupyter-short    up 1-00:00:00      2   drng pe[1-2]
+   grid             up 3-00:00:00      1  drain pe76
+
+You can specify a partition to be listed by ``sinfo``
+
+::
+   $ sinfo --partition=debug
+   PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
+   debug        up    1:00:00      1 drain* wsm1
+   debug        up    1:00:00      1  drain pe3
+   debug        up    1:00:00      1   idle pe83
+
+Take a look at the manpage using ``man sinfo`` for more details. 
+
+Generally, you don't need to specify the partition; Slurm will
+use any posssible partition. However, you can do so with ``-p PARTITION_NAME``
+This is mainly needed if you want to force interactive or
+debug partition (Slurm usually runs short jobs on the debug partition).
+
+.. seealso::
+
+   You can see the partitions in the :doc:`quick
+   reference<../ref/index>`.
+
+Full reference
+==============
+.. include:: ../ref/slurm.rst
+
+.. seealso::
+
+   There is a full description of `running jobs on
+   Triton <../usage/general>`, and the `reference
+   page <../ref/index>` lists many useful commands.
 
 Exercises
 =========
 
-1. Basics
+1. Submit a batch job that just runs ``hostname``.
 
-   a. Submit a batch job that just runs ``hostname``.
-   b. Set time to 1 hour and 15 minutes, memory to 500MB.
-   c. Change the job's name and output file.
-   d. Monitor the job with ``slurm watch queue``.
-   e. Check the output.  Does it match ``slurm history``?
+   a. Set time to 1 hour and 15 minutes, memory to 500MB.
+   b. Change the job's name and output file.
+   c. Monitor the job with ``slurm watch queue``.
+   d. Check the output.  Does it match ``slurm history``?
 
 2. Create a simple batch script using ``pi.py`` based on the pi
    calculation of the :doc:`interactive job tutorial exercises
    <interactive>`.  Create multiple job steps (separate ``srun``
    lines), each of which runs ``pi.py`` with a greater and greater
-   number of tries.  How does this appear in ``slurm history``.  When
+   number of tries.  How does this appear in ``slurm history``?  When
    would you use extra ``srun`` commands, and when not?
 
 3. Create a batch script which does nothing (or some pointless
@@ -205,14 +205,8 @@ Exercises
 4. (Advanced) Create a batch script that runs in another language.
    Does it run?  What are some of the advantages and problems here?
 
-
-Next steps
-==========
-
-There is a full description of `running jobs on
-Triton <../usage/general>`, and the `reference
-page <../ref/index>` lists many useful commands.
+What's next?
+============
 
 Running multiple instances of a ``sbatch`` script is easier with
-:doc:`array jobs<../tut/array>`.
-
+:doc:`array jobs<../tut/array>`. 


### PR DESCRIPTION
I restructured the `array.rst` documentation and incorporated the Pi script into the on-page
examples. There are still some todos and things to consider:

- The `Reading input files` section is not changed much yet. I wanted to use the `pi_aggregation.py` script for this part, so I will make the changes after the script is reviewed.
- There was an allusion to parallel array jobs that I removed. I thought it's best to have it in the parallel documentation. What do you think?
- I will add a short example for 2D sampling and `%N` use cases. 
- Perhaps an exercise regarding the use of `--ntasks` and how it differs from job array should be added?