### PR TITLE
Correction to host name of NBE department server

### DIFF
--- a/aalto/remoteaccess.rst
+++ b/aalto/remoteaccess.rst
@@ -16,7 +16,7 @@ Linux shell servers
       access to workstations and has file systems mounted, use the ``kinit``
       command first if project directories are not accessible)
 
-   - NBE: ``amor.nbe.aalto.fi``, same as above.
+   - NBE: ``amor.org.aalto.fi``, same as above.
    
    - Math: ``elliptic.aalto.fi``, ``illposed.aalto.fi``, 
      same as above (but no project, archive and scratch directories)


### PR DESCRIPTION
Apparently server with name amor.nbe.aalto.fi does not exist. 