### PR TITLE
Kickstart HTCondor links

### DIFF
--- a/training/scip/summer-kickstart.rst
+++ b/training/scip/summer-kickstart.rst
@@ -212,12 +212,12 @@ informal help session to get you started with the computing resources.
     // Did you know that department workstations can be used for
     distributed computing? HTCondor lets you // Matthew West
 
-    * `Users Manual <https://htcondor.readthedocs.io/en/latest/users-manual/index.html>`
-    * Binder: `https://mybinder.org/v2/gh/htcondor/htcondor-python-bindings-tutorials/master?urlpath=lab/tree/index.ipynb`
+    * `Users Manual <https://htcondor.readthedocs.io/en/latest/users-manual/index.html>`__
+    * Binder: `https://mybinder.org/v2/gh/htcondor/htcondor-python-bindings-tutorials/master?urlpath=lab/tree/index.ipynb`__
     * Python Bindings
       
-      * Quickstart: `Submitting and Managing Jobs <https://htcondor.readthedocs.io/en/latest/apis/python-bindings/users/Submitting-and-Managing-Jobs.html>`
-      * Making a workflow: `Diamond DAG <https://github.com/htcondor/htcondor-dags/tree/master/examples/basic_diamond>`
+      * Quickstart: `Submitting and Managing Jobs <https://htcondor.readthedocs.io/en/latest/apis/python-bindings/users/Submitting-and-Managing-Jobs.html>`__
+      * Making a workflow: `Diamond DAG <https://github.com/htcondor/htcondor-dags/tree/master/examples/basic_diamond>`__
 
 
 

--- a/training/scip/summer-kickstart.rst
+++ b/training/scip/summer-kickstart.rst
@@ -212,6 +212,14 @@ informal help session to get you started with the computing resources.
     // Did you know that department workstations can be used for
     distributed computing? HTCondor lets you // Matthew West
 
+    * `Users Manual <https://htcondor.readthedocs.io/en/latest/users-manual/index.html>`
+    * Binder: `https://mybinder.org/v2/gh/htcondor/htcondor-python-bindings-tutorials/master?urlpath=lab/tree/index.ipynb`
+    * Python Bindings
+      
+      * Quickstart: `Submitting and Managing Jobs <https://htcondor.readthedocs.io/en/latest/apis/python-bindings/users/Submitting-and-Managing-Jobs.html>`
+      * Making a workflow: `Diamond DAG <https://htcondor/htcondor-dags/tree/master/examples/basic_diamond>`
+
+
 
 .. _kickstart-2020-prereq:
 

--- a/training/scip/summer-kickstart.rst
+++ b/training/scip/summer-kickstart.rst
@@ -217,7 +217,7 @@ informal help session to get you started with the computing resources.
     * Python Bindings
       
       * Quickstart: `Submitting and Managing Jobs <https://htcondor.readthedocs.io/en/latest/apis/python-bindings/users/Submitting-and-Managing-Jobs.html>`
-      * Making a workflow: `Diamond DAG <https://htcondor/htcondor-dags/tree/master/examples/basic_diamond>`
+      * Making a workflow: `Diamond DAG <https://github.com/htcondor/htcondor-dags/tree/master/examples/basic_diamond>`
 
 
 


### PR DESCRIPTION
Just adding the links to HTCondor tutorials and documentation. I have checked that the links work.