### PR TITLE
Add a new "/help" page.

### DIFF
--- a/help.rst
+++ b/help.rst
@@ -50,7 +50,7 @@ consist of PhD-level researchers.  Our main sub-programs are
 
 * Problems with Triton, using Triton
 * Help with software on Triton
-* Data advice, FAIR data
+* Data advice, FAIR data, confidential data, data organization
 * Suggestions on tools and workflows to use
 * General research software and research tools
 * Advice on other Aalto services
@@ -72,7 +72,7 @@ You can reach us by:
 * Weekly :doc:`SciComp Garage sessions </news/garage>`, where you can
   informally chat.  Especially useful when your question is not yet
   fully defined.
-
+* You can chat with us on `Aalto Microsoft Teams <https://teams.microsoft.com/l/team/19%3a688ad82e41aa46d48ad978aea767419c%40thread.tacv2/conversations?groupId=4089981d-a443-493d-ae3e-3df5c63caed6&tenantId=ae1a7724-4041-4462-a6dc-538cb199707e>`__. This is useful for quick things.
 
 
 Department IT

--- a/help.rst
+++ b/help.rst
@@ -1,0 +1,170 @@
+Help
+====
+
+There are many ways to get help with your scientific computing and
+data needs - in fact, so many you don't know what to use.  This page
+lists who is available to help you, and ways of contacting them.
+
+
+Formulate your question
+-----------------------
+
+We get many requests for help which are too vague to give a useful
+response, so we delay while we try to find something better than
+"please explain more", which slows everything down.  So, when sending
+us a question, always try to clarify these points to get the fastest
+solution:
+
+* **Has it ever worked?**  (If so, what has changed?)
+* **What are you trying to accomplish?**  (Your `ultimate goal
+  <https://en.wikipedia.org/wiki/XY_problem>`__, not current technical
+  obstacle.)
+* **What did you do?**  (Be specific enough to be reproducible - copy and
+  paste exact commands you run, exact output messages, scripts, inputs, etc.)
+
+If you don't know something, it's OK, just explain the best you can
+and we'll go from there!  You can also chat with us to brainstorm
+about issues in general, which helps to figure out these questions.  A
+much more detailed guide is available from `Sigma2 documentation
+<https://documentation.sigma2.no/help/how_to_write_good_support_requests.html>`__.
+
+We don't need a long story in the first message - we'll ask for more
+later.  Try to cover these points, and we are happy to get your
+message.
+
+
+
+Places to ask for help
+----------------------
+
+At Aalto, there are many different places to ask for help.
+
+
+Scientific Computing, Triton, and HPC
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+We are focused on all aspects of computing and data, and mostly
+consist of PhD-level researchers.  Our main sub-programs are
+**high-performance computing** (:doc:`Triton </triton/index>`),
+**research software help** (:doc:`RSEs </rse/index>`), and **data**.
+
+* Problems with Triton, using Triton
+* Help with software on Triton
+* Data advice, FAIR data
+* Suggestions on tools and workflows to use
+* General research software and research tools
+* Advice on other Aalto services
+* Advice on using CSC services
+* Triton Accounts (by email)
+* Increasing quotas, requesting group storage space (by email)
+
+You can reach us by:
+
+* This website
+* The `Triton issue tracker
+  <https://version.aalto.fi/gitlab/AaltoScienceIT/triton/issues>`__,
+  which is where most Triton and scientific computing issues should
+  go, even if not directly Triton related.
+* There is also an email address (get it from our `internal wiki
+  <https://wiki.aalto.fi/display/Triton/Getting+help>`__).  Use this
+  only for things related to your account, quota, etc. - most other
+  things go to the tracker above.
+* Weekly :doc:`SciComp Garage sessions </news/garage>`, where you can
+  informally chat.  Especially useful when your question is not yet
+  fully defined.
+
+
+
+Department IT
+~~~~~~~~~~~~~
+
+CS, NBE, and PHYS have their own IT groups (among others, but those
+are the Science-IT departments with the most support).  They handle
+local matters and can reliably direct you to the right resources.
+Department IT handles:
+
+* Computers, laptops, personal devices
+* Department data storage spaces
+* Other department-managed tools and services
+
+Reach them by:
+
+* Department-specific email addresses
+
+NBE and PHYS IT use the same email issue tracker (esupport) as Aalto
+IT, so issues can be exchanged no matter which address you send an
+issue to.  CS uses a different one, so you have to think a bit more
+before sending something.
+
+
+
+
+servicedesk, Aalto IT
+~~~~~~~~~~~~~~~~~~~~~
+
+servicedesk()aalto.fi is the general IT Services service desk.  They
+can handle things with account, devices, and so on.  They have a wide
+range of responsibilities, but don't always know about local resources
+that may be more appropriate for your needs.  There is an "IT Services
+for Research" group which focuses on research needs
+
+For students (who aren't also researchers), this is always your first
+point of contact - in addition to your teacher.
+
+servicedesk handles:
+
+* Aalto accounts, passwords (including Triton passwords)
+* University-wide data storage (work, teamwork, home directories)
+* All university-wide common IT infrastructure: wifi, network,
+  devices, websites, learning platforms, etc.
+* Anything department stuff, when you are not in a department with
+  local IT staff.
+
+Reach them by:
+
+* `Email or phone <https://www.aalto.fi/en/node/109031/>`__
+* Browse the `IT Services for Research list
+  <https://www.aalto.fi/en/services/it-services-for-research>`__
+
+
+
+Research services
+~~~~~~~~~~~~~~~~~
+
+Aalto `Research Services
+<https://www.aalto.fi/en/service-entities/research-and-innovation-services>`__
+function more as project administative services rather than close
+research support.  However, they provide important information for:
+
+* Data management plans for funding applications
+* Legal or ethical advice, making contracts and NDAs.
+* Library services
+* Applying for funding and administering it.
+
+In many cases, you can chat with Aalto Scientific Computing and we can
+give some initial practical advice.
+
+Reach research services by:
+
+* Contacting service email addresses at the link above
+* Contacting school representatives findable at the link above
+
+
+
+Community
+---------
+
+In addition to formal support, there is are informal activities, too:
+
+* The weekly :doc:`SciComp Garage </news/garage>`, designed to provide
+  one-on-one help, but we invite anyone to come, hang out in the main
+  room, and network with us.  This is for basic help and brainstorming.
+
+* Subscribe to notifications from the `Triton issue tracker
+  <https://version.aalto.fi/gitlab/AaltoScienceIT/triton/issues>`__
+  even if you don't post there.  You will learn a lot.
+
+* Sign up for the `Research software engineers and powerusers mailing
+  list <https://list.aalto.fi/mailman/listinfo/rse>`__ and learn about
+  more events that interest you.  This isn't the place to ask for
+  basic help, but if you hang out here you will learn a *lot*.


### PR DESCRIPTION
- A user had requested one page to use to answer "who should I ask for
  help and how?", since there are so many different places and email
  addresses.  This is the first step of that.

- This should eventually be integrated with:
  - https://scicomp.aalto.fi/aalto/welcomeresearchers/ (and welcomestudents)
  - https://scicomp.aalto.fi/triton/help/
  - and information de-duplicated
  - RSEs should be more prominently mentioned.

- To review
  - Does this present a fair picture of the situation?
  - Have I forgotten anything the services do?
  - Have I forgotten any services that need to be mentioned?
  - Have I provided good advice on triaging to the different services?
  - Is it too long?  Can it be made much shorter?
  - Suggestions for de-duplicating.