### PR TITLE
about/cs-it: Add initial CSIT page

### DIFF
--- a/about/cs-it.rst
+++ b/about/cs-it.rst
@@ -1,0 +1,67 @@
+Computer Science IT
+===================
+
+Computer Science IT provides advanced computing, data, and IT services
+to the Department of Computer Science.  Ten years ago,
+we focused on daily infrastructure and devices.  We still do that, but
+our we now serve a far broader mission including teaching and
+services, data management, specialised research tools, and cloud
+services.
+
+
+
+Our services
+------------
+
+We:
+
+* Handle daily device and infrastructure needs
+
+* Develop and maintain department services, such as
+  :doc:`jupyter.cs.aalto.fi </aalto/jupyterhub>` or the department
+  services database lapa.aalto.fi
+
+* Help co-maintain other platforms developed by researchers or
+  teachers
+
+* Provide services for :doc:`managing the department's research data
+  </aalto/aaltodata>`
+
+* `Provide virtual machines
+  <https://wiki.aalto.fi/display/CSdept/IT>`__.
+
+* Provide advanced consultation for IT needs for research
+
+... but most basic IT tools are handled by Aalto IT Services, not
+us.  We build on their work and make sure research and teaching goes
+as quickly as possible.
+
+(also note, we don't primarily serve CS undergraduate students)
+
+
+Work for CS-IT
+--------------
+
+We are always looking for students interested in IT, programming, and
+system administration.  We also are a good place for civil service.
+The most important prerequisites are a good understanding of Linux and
+a never-ending desire to learn more.  Buzzwords you are likely to
+become familiar with/useful skills to have:
+
+* Kubernetes, docker, and virtual machines
+* Web service development
+* Puppet (and Ansible)
+* Data and storage systems
+* Computer hardware, building high-performance workstations
+
+
+
+Contact
+-------
+
+You can always drop by room A243 if we are there, or contact us by the
+`email address findable on our internal wiki
+<https://wiki.aalto.fi/display/CSdept/IT>`__.
+
+See our members on the :doc:`About Aalto Scientific Computing page
+</about/index>`.

--- a/about/cs-it.rst
+++ b/about/cs-it.rst
@@ -15,22 +15,22 @@ Our services
 
 We:
 
-* Handle daily device and infrastructure needs
+* Handle daily device and infrastructure needs.
 
 * Develop and maintain department services, such as
   :doc:`jupyter.cs.aalto.fi </aalto/jupyterhub>` or the department
-  services database lapa.aalto.fi
+  services database lapa.aalto.fi.
 
 * Help co-maintain other platforms developed by researchers or
-  teachers
+  teachers.
 
 * Provide services for :doc:`managing the department's research data
-  </aalto/aaltodata>`
+  </aalto/aaltodata>`.
 
 * `Provide virtual machines
   <https://wiki.aalto.fi/display/CSdept/IT>`__.
 
-* Provide advanced consultation for IT needs for research
+* Provide advanced consultation for IT needs for research.
 
 ... but most basic IT tools are handled by Aalto IT Services, not
 us.  We build on their work and make sure research and teaching goes
@@ -59,8 +59,9 @@ become familiar with/useful skills to have:
 Contact
 -------
 
-You can always drop by room A243 if we are there, or contact us by the
-`email address findable on our internal wiki
+You can always drop by room A243 if we are there (not during covid-19,
+please) or join the :doc:`daily online garage </news/garage>`, or
+contact us by the `email address findable on our internal wiki
 <https://wiki.aalto.fi/display/CSdept/IT>`__.
 
 See our members on the :doc:`About Aalto Scientific Computing page

--- a/about/index.rst
+++ b/about/index.rst
@@ -99,7 +99,14 @@ Computer Science, Physics, and Neuroscience and Biomedical Engineering
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 These departments are members of Science-IT, and their local IT staff
-provide the greatest Science-IT support.
+provide a great deal of scientific computing support, and in fact all
+the Science-IT team above is contained here.  These departments resources
+are seamlessly integrated with Aalto's HPC resources.
+
+.. toctree::
+   :maxdepth: 1
+
+   cs-it
 
 
 Partners


### PR DESCRIPTION
- Draft with some basic info
- To review
  - What else do we do?
  - Is the "work for us" appropriate?
  - Add our group members to the about page, if desired.
  - Can look at the science-it page for inspiration of what else can
    go here
  - What else should be moved to scicomp.aalto.fi instead of internal
    wiki?