### PR TITLE
Adjust primary names in the table of contents

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-================
-About these docs
-================
+===============
+About this site
+===============
 
 These docs originally came from the Triton User Guide, but now serves
 as a general Aalto scientific computing guide.  The intention is a

--- a/aalto/index.rst
+++ b/aalto/index.rst
@@ -1,6 +1,6 @@
-=====================
-The Aalto environment
-=====================
+===========
+Aalto tools
+===========
 
 For more services provided at the Aalto level, see the `IT Services
 for Research page

--- a/scicomp/index.rst
+++ b/scicomp/index.rst
@@ -1,6 +1,6 @@
-====================
-Scientific computing
-====================
+=========================
+Scientific computing tips
+=========================
 
 .. toctree::
    :maxdepth: 1

--- a/triton/index.rst
+++ b/triton/index.rst
@@ -1,6 +1,6 @@
-=================
-Triton user guide
-=================
+==============
+Triton cluster
+==============
 
 Triton is the Aalto high-performance computing cluster.  It serves all
 researchers


### PR DESCRIPTION
* "Triton user guide" -> "Triton cluster".

  "user guide" seems unnecessary here, there is no longer any
  confusion.  "The Triton cluster" would be more appropriate but "the"
  is an unnecessary word.

* "The Aalto environment" -> "Aalto tools".

  This always seemed like a weird name to me.  Just "Aalto" seems too
  broad, "Aalto tools" is what I settled on for now.  It could also be
  "Aalto environment" but I don't quite like that.  Any ideas?

* "Scientific computing" -> "Scientific computing tips".

  "Scientific Computing" was too broad, everything here is scientific
  computing.  I also considered "Scientific computing in general".

* "About these docs" -> "About this site"

  Seems simple and reasonable... I'm wondering if this could be put
  into some other subsection, but it probably best goes where it is now.

To review: do these names make sense?  What would be better, I'm still
not fully convinced of them.