### PR TITLE
Remove old links to science-it.aalto.fi and improve ASC description

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,12 +12,15 @@ Contributing
 
 This documentation is Open Source (CC-BY 4.0), and we welcome
 contributions from the Aalto community.  The project is run on Github
-(https://github.com/AaltoSciComp/scicomp-docs).
+in the repository `AaltoSciComp/scicomp-docs <https://github.com/AaltoSciComp/scicomp-docs>`__.
 
 To contribute, you can always use the normal Github contribution
-mechanims: make a pull request or comments.  If you are at Aalto, you
+mechanisms: make a `pull request`__, issues__, or comments.  If you are at Aalto, you
 can also get direct write access.  Make a github issue, then contact
 us in person/by email for us to confirm.
+
+__ https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/proposing-changes-to-your-work-with-pull-requests
+__ https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues
 
 **The worst contribution is one that isn't made.** Don't worry about
 making things perfect: since this is in version control, we track all
@@ -29,14 +32,16 @@ the basics are similar).
 When you submit a change, there is continuous testing that will notify
 you of errors, so that you can make changes with confidence.
 
-Contributing gives consent to use content under the licenses (CC-BY
+Contributing gives agreement to use content under the licenses (CC-BY
 4.0 or CC0 for examples).
 
 
 Requirements and building
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To build the docs, run ``make html``.
+To build the docs, run ``make html``.  You can run ``make clean
+check`` to build it and report only the errors that would cause a
+failure.
 
 There is a ``requirements.txt`` file, but the only real Python
 dependencies to do basic tests is ``sphinx`` and ``sphinx_rtd_theme``

--- a/aalto/welcomeresearchers.rst
+++ b/aalto/welcomeresearchers.rst
@@ -33,8 +33,8 @@ some of the key players:
   PHYS.  Science-IT runs a weekly :doc:`SciComp garage
   <../news/garage>`, where we provide hands on support for anything
   related to scientific computing.
-  :doc:`This site (scicomp.aalto.fi) <../index>` is the main home, but
-  there is also an `formal site <sci-it_>`_.
+  :doc:`This site (scicomp.aalto.fi) <../index>` is the main home,
+  read more about us on the :doc:`about page</about/index>`.
 * **Aalto IT Services (ITS)**: Provides central IT infrastructure.
   They have a "Services for Research" group, but it is less
   specialized than Science-IT. ITS may be the first place to
@@ -55,7 +55,6 @@ some of the key players:
   <https://research.csc.fi/>`_
 
 .. _its_instr: https://aalto.fi/it
-.. _sci-it: http://science-it.aalto.fi/
 .. _cs-it: https://wiki.aalto.fi/display/CSdept/IT
 .. _nbe-it: https://wiki.aalto.fi/display/NBE/IT+Information
 .. _phys-it: https://wiki.aalto.fi/display/TFYintra/PHYS+IT

--- a/index.rst
+++ b/index.rst
@@ -7,13 +7,16 @@
 Aalto Scientific Computing
 ==========================
 
-This contains documentation about scientific and data-intensive computing
+This site contains documentation about scientific and data-intensive computing
 at Aalto and beyond.  It is targeted towards Aalto researchers, but
 has some useful information for everyone.  The data management section
 is useful even to non-computational researchers.
 
-These docs are maintained by `Aalto Science-IT
-<http://science-it.aalto.fi>`_ with the help of the Aalto community.
+:doc:`Aalto Scientific Computing
+</about/index>` maintains these pages with the :doc:`help of the Aalto community <README>`.
+[`twitter <https://twitter.com/SciCompAalto>`__]  We consist of
+Science-IT (HPC, the Triton cluster), certain department ITs, and
+other friends.  :doc:`You can join us </about/join>`.
 
 .. toctree::
    :maxdepth: 1

--- a/triton/accounts.rst
+++ b/triton/accounts.rst
@@ -31,16 +31,14 @@ A few prerequisites:
 
    - Researchers (as in, affiliated with a research PI in any way).
      Please tell us who your supervisor is in your account request.
-   - Students coming to one of our `Scientific Computing in Practice
-     courses <scip_>`_ which uses Triton.  You will be specifically
+   - Students coming to one of our :doc:`Scientific Computing in Practice
+     courses </training/scip/index>` which uses Triton.  You will be specifically
      told if this is the case
    - Other students not doing research needing computational
      facilities should check out our :doc:`introduction for students
      <../aalto/welcomestudents>`.  **This includes most student
      projects as part of courses, unless you are effectively joining a
      research group to do a project.**
-
-.. _scip: http://science-it.aalto.fi/scip/
 
 You know that you have Triton access if you are in the ``triton-users``
 group at Aalto: ``groups`` shows this on Aalto linux machines.

--- a/triton/help.rst
+++ b/triton/help.rst
@@ -147,7 +147,7 @@ We have regular training in topics relevant to HPC and scientific
 computing.  In particular, each January and June we have a "kickstart"
 course which teaches you everything you need to know to do HPC work.
 Each Triton user should come to one of these.  For the schedule, see
-`our training page <http://science-it.aalto.fi/scip/>`__.
+:doc:`our training page </training/scip/index>`.
 
 
 Getting a detailed bug report with triton-record-environment

--- a/triton/index.rst
+++ b/triton/index.rst
@@ -23,8 +23,6 @@ Quick contents and links
          * :doc:`overview`
          * :doc:`usagepolicy`
 	 * :doc:`acknowledgingtriton`
-	 * `Aalto Science-IT <http://science-it.aalto.fi>`_ (external
-	   link)
 
        * :doc:`Getting Help/Contact <help>`
 
@@ -71,9 +69,9 @@ Quick contents and links
 
        **Scientific computing resources**
 
-       * `SCIP – Scientific Computing in Practice courses
-	 <http://science-it.aalto.fi/scip/>`_: organized
-	 by Science IT. Including Triton kickstarts and many others
+       * :doc:`SCIP – Scientific Computing in Practice courses
+	 </training/scip/index>`: organized
+	 by SciComp. Including Triton kickstarts and many others
        * `Parallel computing <https://wiki.aalto.fi/download/attachments/65022076/parallel_computing.2012-04-12.pdf?version=1&modificationDate=1334828664000&api=v2>`_
        * `Aalto IT Services for Research <https://www.aalto.fi/en/services/it-services-for-research>`_
        * `Software Carpentry <https://software-carpentry.org/>`_

--- a/triton/tut/intro.rst
+++ b/triton/tut/intro.rst
@@ -10,10 +10,6 @@ department (now part of CS), Biomedical Engineering and Computational
 Science department (now NBE), and Applied Physics department.  Now, it
 still serves all Aalto and is organized from the School of Science.
 
-Our basic administrative web page is http://science-it.aalto.fi, but
-it has mostly administrative info.  This site,
-https://scicomp.aalto.fi, is our practical info for users.
-
 You are now at the first step of the Triton tutorial.
 
 


### PR DESCRIPTION
- Remove old links to science-it.aalto.fi (except link that don't
  currently have a replacement)
- Take the opportunity to update some of the general ASC
  meta-information on the main pages, since this is now the main page.