### PR TITLE
footer: Add explicit "welcome contributions" footer

### DIFF
--- a/_templates/footer.html
+++ b/_templates/footer.html
@@ -1,9 +1,14 @@
 {%- extends "!footer.html" %}
 
 {% block extrafooter %}
+
+<p style="margin-top: 12px">
   {%- if gitstamp %}
-    <p style="margin-top: 12px">
       <span class="lastupdated">This page last updated {{ gitstamp }}.</span>
-    </p>
   {%- endif %}
+  This site is made for Aalto Scientific Computing,
+  but we <a href="https://github.com/AaltoSciComp/scicomp-docs">welcome
+  contributions</a> that make it more useful to others, too.  Built
+  with <a href="https://www.sphinx-doc.org/">Sphinx</a>.
+</p>
 {% endblock %}

--- a/conf.py
+++ b/conf.py
@@ -208,6 +208,7 @@ html_static_path = ['_static']
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
 #html_show_sphinx = True
+html_show_sphinx = False
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
 #html_show_copyright = True


### PR DESCRIPTION
- Add a text that says " This site is made for Aalto Scientific
  Computing, but we welcome contributions that make it more useful to
  others, too."  Outside readers shouldn't think this is "us or them",
  while specific to us we can make it useful to others, too.
- set html_show_sphinx to False to keep the footer from growing too
  long.  Instead, include it in this new paragraph.