### PR TITLE
triton/accounts: Link to HoSC and Tutorials when making accounts

### DIFF
--- a/triton/accounts.rst
+++ b/triton/accounts.rst
@@ -18,27 +18,31 @@ department, supervisor, Aalto account, and see the conditions below.
 
 A few prerequisites:
 
--  you must have valid Aalto account
--  you must have working email address (Aalto)
--  you must accept :doc:`Triton usage
-   policies <usagepolicy>`: requesting access to
-   Triton cluster at Aalto University, you accept all the conditions
-   listed in the Triton usage policies, including the data and privacy
+-  You must have valid Aalto account
+-  You must accept :doc:`Triton usage
+   policies <usagepolicy>`, including the data and privacy
    policies.
--  You should tell us your department/school in your account creation
+-  Also tell us your department/school in your account creation
    request.
--  Accounts are for
+-  You should have enough background to use Triton well, including
+   Linux skills.  Read
+   `hands-on scientific computing
+   <https://handsonscicomp.readthedocs.io/en/latest/>`__, and you
+   should know A ("Basics"), C ("Linux"), and D ("HPC") well.  Also
+   see the :ref:`Triton tutorials <tutorials>`.
 
-   - Researchers (as in, affiliated with a research PI in any way).
-     Please tell us who your supervisor is in your account request.
-   - Students coming to one of our :doc:`Scientific Computing in Practice
-     courses </training/scip/index>` which uses Triton.  You will be specifically
-     told if this is the case
-   - Other students not doing research needing computational
-     facilities should check out our :doc:`introduction for students
-     <../aalto/welcomestudents>`.  **This includes most student
-     projects as part of courses, unless you are effectively joining a
-     research group to do a project.**
+Accounts are for:
+
+- Researchers (as in, affiliated with a research PI in any way).
+  Please tell us who your supervisor is in your account request.
+- Students coming to one of our :doc:`Scientific Computing in Practice
+  courses </training/scip/index>` which uses Triton.  You will be specifically
+  told if this is the case
+- Other students not doing research needing computational
+  facilities should check out our :doc:`introduction for students
+  <../aalto/welcomestudents>`.  **This includes most student
+  projects as part of courses, unless you are effectively joining a
+  research group to do a project.**
 
 You know that you have Triton access if you are in the ``triton-users``
 group at Aalto: ``groups`` shows this on Aalto linux machines.

--- a/triton/index.rst
+++ b/triton/index.rst
@@ -74,6 +74,8 @@ Quick contents and links
 	 by SciComp. Including Triton kickstarts and many others
        * `Parallel computing <https://wiki.aalto.fi/download/attachments/65022076/parallel_computing.2012-04-12.pdf?version=1&modificationDate=1334828664000&api=v2>`_
        * `Aalto IT Services for Research <https://www.aalto.fi/en/services/it-services-for-research>`_
+       * `Hands-on Scientific Computing <hosc_>`__: map of important
+	 computing skills
        * `Software Carpentry <https://software-carpentry.org/>`_
 	 (scientific computation basics) and
 	 `Code Refinery <https://coderefinery.org/>`_ (more focused on
@@ -110,7 +112,14 @@ Overview
 Tutorials
 =========
 These are designed to be read in-order by every Triton user when they
-get their accounts (except maybe the last ones).
+get their accounts (except maybe the last ones).  In order to use
+Triton well, in the `Hands-on SciComp roadmap <hosc_>`__ you should
+also know the `Basics (A) <hosc-a_>`__ and `Linux (C) <hosc-c_>`__
+levels as a prerequisite.
+
+.. _hosc: https://handsonscicomp.readthedocs.io/en/latest/
+.. _hosc-a: https://handsonscicomp.readthedocs.io/en/latest/#a-basics
+.. _hosc-c: https://handsonscicomp.readthedocs.io/en/latest/#c-linux-and-shell
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
- In the page on Triton accounts, explicitely say that you need proper
 training, and link to HoSC and the Triton tutorials.

- I thought that we could also request people making new accounts to
 tell us how they fit in with this to make it seem a bit more
 serious, but perhaps that is too much to ask.  We also have the
 survey form which people answer after their account is made.