### PR TITLE
/help/community: centralize community info, add page

### DIFF
--- a/help/community.rst
+++ b/help/community.rst
@@ -1,0 +1,82 @@
+SciComp Community
+=================
+
+Let's face it: we learn more from each other than from classes.  How
+can we learn from each other if we don't have a community?  Join the
+Aalto SciComp community to make the most of your time here.
+
+Aalto Scientific Computing hosts many different channels to get
+involved.  Through it, you can:
+
+* Network with others.
+
+* Share knowledge among ourselves (maybe have relevant training,
+  too).  We can't be experts in everything, so if users can help each
+  other, everyone benefits.
+
+* Take part in developing our services - basically, be a voice of the
+  users.
+
+* More directly help the community by, for example, :doc:`directly updating
+  this site </README>`, helping to develop services, or teaching with us.
+
+
+
+SciComp Garage and issues
+-------------------------
+
+Currently, most of our interaction happens in the daily :doc:`SciComp
+Garage <garage>`, which is a daily meeting where we help others (and
+learn ourselves).  If you hang out there, you will learn a lot.
+
+If you subscribe to the `Triton issue tracker
+<https://version.aalto.fi/gitlab/AaltoScienceIT/triton/issues>`__, you
+will see a lot of questions and answers, and thus learn a lot.
+
+
+
+Aalto community chats
+---------------------
+
+We have biweekly chats for the Aalto RSE/scientific computing
+poweruser meetings.  This is a way to network with similarly-minded
+people.  Check back for updates on when these are.
+
+
+
+Mailing lists
+-------------
+
+* If you have a :doc:`Triton account </triton/index>`, you are on the
+  triton-users mailing list already.  Many :doc:`training
+  </training/index>` and other events are announced there.
+* If you do not have a Triton account, the :doc:`scicomp-announcements
+  mailing list </training/scicomp-announcements-maillist>` provides
+  the same information.  `Subscribe
+  here<https://list.aalto.fi/mailman/listinfo/scicomp-announcements>`__.
+* Join `our RSE mailing list
+  <https://list.aalto.fi/mailman/listinfo/rse>`__ for information on
+  research software related topics.
+
+
+
+Chat
+----
+
+* Join the `Aalto Scientific Computing group on Aalto Microsoft Teams
+  <asc-teams_>`__.  The invite code is ``e50tyij``.  In practice, we
+  watch it for questions but it's not the most active place (but it
+  could be).
+* We often hang out on the `CodeRefinery chat
+  <https://coderefinery.github.io/manuals/chat/>`__, and there is an
+  ``#aalto`` stream there.
+
+.. _asc-teams: https://teams.microsoft.com/l/team/19%3a688ad82e41aa46d48ad978aea767419c%40thread.tacv2/conversations?groupId=4089981d-a443-493d-ae3e-3df5c63caed6&tenantId=ae1a7724-4041-4462-a6dc-538cb199707e
+
+
+
+Social media
+------------
+
+* Twitter: [@SciCompAalto](https://twitter.com/SciCompAalto)
+* YouTube: [Aalto Scientific Computing](https://www.youtube.com/channel/UCNErdFO1_GzSkDx0bLKWXOA/)

--- a/help/index.rst
+++ b/help/index.rst
@@ -60,24 +60,25 @@ consist of PhD-level researchers.  Our main sub-programs are
 
 You can reach us by:
 
-* This website
+* Searching this website
 * The `Triton issue tracker
   <https://version.aalto.fi/gitlab/AaltoScienceIT/triton/issues>`__,
   which is where most Triton and scientific computing issues should
   go, even if not directly Triton related.
-* There is also an email address (get it from our `internal wiki
-  <https://wiki.aalto.fi/display/Triton/Getting+help>`__).  Use this
-  only for things related to your account, quota, etc. - most other
-  things go to the tracker above.
 * Weekly :doc:`SciComp Garage sessions </help/garage>`, where you can
   informally chat.  Especially useful when your question is not yet
   fully defined.
 * You can chat with us on `Aalto Microsoft Teams <https://teams.microsoft.com/l/team/19%3a688ad82e41aa46d48ad978aea767419c%40thread.tacv2/conversations?groupId=4089981d-a443-493d-ae3e-3df5c63caed6&tenantId=ae1a7724-4041-4462-a6dc-538cb199707e>`__.  The invite code is ``e50tyij``.  This is useful for quick things.
+* There is also an email address (get it from our `internal wiki
+  <https://wiki.aalto.fi/display/Triton/Getting+help>`__).  Use this
+  only for things related to your account, quota, etc. - most other
+  things go to the tracker above.
 
 .. toctree::
    :maxdepth: 1
 
    garage
+   community
 
 Department IT
 ~~~~~~~~~~~~~

--- a/rse/community.rst
+++ b/rse/community.rst
@@ -22,19 +22,4 @@ make a community of these people.  By taking part, you can:
 * More directly help the community by, for example, :doc:`directly updating
   this site </README>`, helping to develop services, or teaching with us.
 
-
-
-Aalto community chats
----------------------
-
-We have biweekly chats for the Aalto RSE/scientific computing
-poweruser meetings.  This is a way to network with similarly-minded
-people.  Check back for updates on when these are.
-
-Join `our RSE mailing list
-<https://list.aalto.fi/mailman/listinfo/rse>`_ to be kept up to date.
-
-Join the `Aalto Scientific Computing group on Aalto Microsoft Teams
-<asc-teams_>`__.  The invite code is ``e50tyij``.
-
-.. _asc-teams: https://teams.microsoft.com/l/team/19%3a688ad82e41aa46d48ad978aea767419c%40thread.tacv2/conversations?groupId=4089981d-a443-493d-ae3e-3df5c63caed6&tenantId=ae1a7724-4041-4462-a6dc-538cb199707e
+To join the community, see the :doc:`general SciComp community page </help/community>`


### PR DESCRIPTION
- Before, there was /rse/community, but the community is actually
  broader than just RSEs.  Move it to help.  The old page stays there
  for the time being.