### PR TITLE
requirements: Add color contrast module, replaces #164

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -41,6 +41,12 @@ try:
     gitstamp_fmt = "%d %b %Y"
 except:
     print("sphinx_gitstamp is not installed, won't use git timestamps.")
+try:
+    # https://github.com/jdillard/sphinx-gitstamp
+    import sphinx_rtd_theme_ext_color_contrast
+    extensions.append('sphinx_rtd_theme_ext_color_contrast')
+except:
+    print("sphinx_rtd_theme_ext_color_contrast is not installed")
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ sphinx_gitstamp
 #recommonmark
 # For the slurm lexer
 pygments>=2.4
+https://github.com/AaltoSciComp/sphinx_rtd_theme_ext_color_contrast/archive/master.zip


### PR DESCRIPTION
- See #164 for reasoning.

- In short, web accessibility checker showed that there wasn't enough
  contrast in different elements.  This improves it by overriding the
  theme some, but is not a proper fix: it should be fixed upstream here:
    https://github.com/readthedocs/sphinx_rtd_theme/issues/971