### PR TITLE
rse/procedures/time-tracking: Suggestion for RSE time mgmt via Gitlab

### DIFF
--- a/rse/procedures/index.rst
+++ b/rse/procedures/index.rst
@@ -35,3 +35,5 @@ For ourselves
 -------------
 
 .. toctree::
+
+   time-tracking

--- a/rse/procedures/time-tracking.rst
+++ b/rse/procedures/time-tracking.rst
@@ -1,0 +1,32 @@
+Time tracking
+=============
+
+Unfortunately (fortunately?), we have to track our time some, in order
+to justify the benefits of what we do.
+
+Time tracking is done through Gitlab, within the issue opened for each
+"project".
+
+Gitlab commands:
+
+* Use these within the issue as a comment, to control the time
+  allocation.
+* ``/estimate NNw`` - estimate total time a project make take.  Used as
+  soon as possible at beginning of a project, can always be updated
+* ``/spend NNh`` - announce that you have spent a certain amount of time
+  on the project
+* Units: Months (``mo``), Weeks (``w``), Days (``d``), Hours (``h``), Minutes
+  (``m``). Default conversion rates are 1mo = 4w, 1w = 5d, and 1d = 8h.
+
+
+Be aware:
+
+* Be aware that it takes some time to get up to speed with a project.
+  This should be considered when making the initial estimate, during
+  the first consultation.
+* No one can work at 100% at a specific task.  Instead of
+  micro-managing time, our RSE should assume 75% efficiency for the
+  time billed to any given project, with the rest for overhead tasks.
+  This also covers the time spent by other SciComp members spending
+  consulting on projects, and time spent after the project is done
+  with follow-up consultations.

--- a/rse/procedures/time-tracking.rst
+++ b/rse/procedures/time-tracking.rst
@@ -1,6 +1,13 @@
 Time tracking
 =============
 
+.. warning::
+
+   This page is still in draft form and being discussed and
+   developed.  See the note on the parent page.
+
+   This draft may turn out to be especially bad... please comment.
+
 Unfortunately (fortunately?), we have to track our time some, in order
 to justify the benefits of what we do.
 


### PR DESCRIPTION
- Problem: we need to track time somehow, so that we can tell each
  deparment how much benefit they are getting, and how much funding
  each group is providing and which department's funding it replaces.
- This is an initial light suggestion for how we can manage RSE
  projects using Gitlab.  Gitlab isn't exactly the right platform, but
  it is open and the same we should be using for other stuff.
- We would then closely manage the projects using labels and other
  scripts using the Gitlab APIs, to produce reports.
- To review: is this even a good idea?