### PR TITLE
meta/check-warnings: Add error for toctree error

### DIFF
--- a/meta/check-warnings.py
+++ b/meta/check-warnings.py
@@ -21,6 +21,7 @@ errors = [
      "Indirect hyperlink target",
      "Unknown directive type",
      "Anonymous hyperlink mismatch",
+     "toctree contains reference to nonexisting document",
     ]
 
 ignores = [


### PR DESCRIPTION
- "toctree contains reference to nonexisting document" becomes a hard
  error, not a warning.
- To revew: not much I think.