### PR TITLE
{help,rse}/community: link to Nordic-RSE weekly chat.

### DIFF
--- a/help/community.rst
+++ b/help/community.rst
@@ -38,9 +38,12 @@ will see a lot of questions and answers, and thus learn a lot.
 Aalto community chats
 ---------------------
 
-We have biweekly chats for the Aalto RSE/scientific computing
-poweruser meetings.  This is a way to network with similarly-minded
-people.  Check back for updates on when these are.
+We have weekly chats for the Aalto scientific computing
+poweruser/RSEs as a way to network with the community and Aalto staff.
+Currently, these are done at `10:00 on Thursdays as part of
+the Nordic-RSE Finland chats
+<https://nordic-rse.org/communities/finland/>`__.  Anyone is welcome
+to join and discuss Aalto-related topics.
 
 
 
@@ -54,9 +57,9 @@ Mailing lists
   mailing list </training/scicomp-announcements-maillist>` provides
   the same information.  `Subscribe
   here <https://list.aalto.fi/mailman/listinfo/scicomp-announcements>`__.
-* Join `our RSE mailing list
+* Join `our Research Software Engineer mailing list
   <https://list.aalto.fi/mailman/listinfo/rse>`__ for information on
-  research software related topics.
+  research software related topics and the RSE community at Aalto.
 
 
 

--- a/rse/community.rst
+++ b/rse/community.rst
@@ -22,4 +22,8 @@ make a community of these people.  By taking part, you can:
 * More directly help the community by, for example, :doc:`directly updating
   this site </README>`, helping to develop services, or teaching with us.
 
-To join the community, see the :doc:`general SciComp community page </help/community>`
+To join the community, see the :doc:`general SciComp community page
+</help/community>`.  Also, you should take part in the `Nordic-RSE
+Finland chats <https://nordic-rse.org/communities/finland/>`__ - there
+is a strong Aalto presence there, and we use that as our Aalto chat
+time, too.


### PR DESCRIPTION
- As discussed with @rantahar, we can direct all Aalto scicomp people
  to the Nordic-RSE Finland chat.  Can rethink this if too many people
  show up.
- To review:
  - Is the wording good?  Is the whole community section too long and
    confusing?
  - @rantahar: is this good wording?