### PR TITLE
editing the news page to make it more uptodate reflect daily news

### DIFF
--- a/news/index.rst
+++ b/news/index.rst
@@ -2,12 +2,12 @@
 News
 ====
 
-*15/09/2020* – Our course on `"Python for Scientific Computing" </training/scip/python-for-scicomp>` is ongoing, next session is tomorrow. It can also be watched `live on CodeRefinery Twitch <https://www.twitch.tv/coderefinery>`__ if you did not have time to register. Check `other trainings coming in October and November </training/#scientific-computing-in-practice>`. Join our `daily garage </help/garage>` if you have issues to discuss related to computing or data management.
+*15/09/2020* – Our course on `"Python for Scientific Computing" </training/scip/python-for-scicomp>`__ is ongoing, next session is tomorrow. It can also be watched `live on CodeRefinery Twitch <https://www.twitch.tv/coderefinery>`__ if you did not have time to register. Check :doc:`other trainings coming in October and November </training/index>`. Join our :doc:`daily garage </help/garage>` if you have issues to discuss related to computing or data management.
 
 .. toctree::
-      :maxdepth: 1
-   
-   ../training/scip/python-for-scicomp.rst
-   ../training/
-   ../help/garage.rst
+   :maxdepth: 1
+
+   ../training/scip/python-for-scicomp
+   ../training/index
+   ../help/garage
    ../training/scicomp-announcements-maillist

--- a/news/index.rst
+++ b/news/index.rst
@@ -2,10 +2,12 @@
 News
 ====
 
-.. toctree::
-   :maxdepth: 1
+*15/09/2020* – Our course on `"Python for Scientific Computing" </training/scip/python-for-scicomp>` is ongoing, next session is tomorrow. It can also be watched `live on CodeRefinery Twitch <https://www.twitch.tv/coderefinery>`__ if you did not have time to register. Check `other trainings coming in October and November </training/#scientific-computing-in-practice>`. Join our `daily garage </help/garage>` if you have issues to discuss related to computing or data management.
 
-   garage.rst
-   2019_jupyterworkshop.rst
-   powerusers-group
+.. toctree::
+      :maxdepth: 1
+   
+   ../training/scip/python-for-scicomp.rst
+   ../training/
+   ../help/garage.rst
    ../training/scicomp-announcements-maillist


### PR DESCRIPTION
I would like to update the /news/index.rst daily to reflect news/upcoming events or other things worth mentioning.

I am unsure about some of the syntax (will the toctree work?) but hopefully it's quick to fix by who reviews this :)

