### PR TITLE
news/garage: Redirect /news/garage/ to /help/garage/

### DIFF
--- a/news/garage.rst
+++ b/news/garage.rst
@@ -2,7 +2,10 @@
 Scicomp garage
 ==============
 
-.. seealso:: This page has been moved to :doc:`/help/garage`.  Below
-	     is an included for your convenience.
+.. seealso:: This page has been moved to :doc:`/help/garage` - please
+	     go there.
 
-.. include:: /help/garage.rst
+.. raw:: html
+
+      <meta http-equiv="Refresh" content="0; url='../help/garage/'" />
+


### PR DESCRIPTION
- This removes the weird toctree effect where navigating to
  /help/garage makes you end up in /help/garage.

- It uses raw HTML to redirect it, which I think isn't ideal but
  simple and seems to work locally, and I hope redirects search
  engines to the right place.

- There are HTTP redirects in readthedocs, but then we stay locked in
  to readthedocs.

- Review: consider if this is a good idea and if there is a better
  Sphinx option.

  - Update: I just saw
    https://github.com/wpilibsuite/sphinxext-rediraffe, which is
    released less than a month ago, which is why I didn't see it
    before.  Perhaps consider that instead of this.