### PR TITLE
training/scip/data-analysis: Updating data analysis course name

### DIFF
--- a/training/scip/data-analysis.rst
+++ b/training/scip/data-analysis.rst
@@ -1,6 +1,6 @@
-===============================================
-Oct 2020 / Data analysis with R and Python
-===============================================
+====================================================
+Oct 2020 / Data analysis workflows with R and Python
+====================================================
 
 Part of the `Scientific Computing in Practice <https://scicomp.aalto.fi/training/scip/index.html>`__ lecture series at Aalto University.
 
@@ -44,6 +44,7 @@ Science
 employees and students.
 
 **Registration:** `registration is open <https://link.webropolsurveys.com/S/9F2A504AF3088DBD>`__
+(name of the course has changed since creation of the registration link).
 
 **Credits:** Credits available for the Aalto students and course
 certificate can be provided on request for the outsiders. Full course

--- a/training/scip/data-analysis.rst
+++ b/training/scip/data-analysis.rst
@@ -54,7 +54,7 @@ at least 3 of 4 lectures.
 
 **Other comments:** 
 
-**Additional course info at:** simo.tuomisto -at- aalto.fi
+**Additional course info at:** scip -at- aalto.fi
 
 **Course preparation**
 


### PR DESCRIPTION
This PR changes the name of the data analysis course to reflect the change in the materials.