### PR TITLE
rse: add units-info and advisory board pages

### DIFF
--- a/rse/procedures/advisory-board.rst
+++ b/rse/procedures/advisory-board.rst
@@ -1,0 +1,47 @@
+Advisory board
+==============
+
+.. warning::
+
+   This page is a draft.
+
+This page describes the advisory board of the Aalto RSE program and
+hosts the results of its meetings.  Out of principle, all material is
+open on this page (though specific items may be retracted).
+
+
+
+Purpose of the advisory board
+-----------------------------
+
+The advisory board provides advice to the strategy and day to day
+implementation of the Aalto RSE program and its relation to scientific
+computing and teaching at Aalto.
+
+
+
+Current advisory board
+----------------------
+
+* SCI:
+* CS:
+* NBE:
+* PHYS:
+* ...
+* ...
+
+
+
+Meetings
+--------
+
+Topics for the next meeting and results from previous meetings are
+located here, newest first.
+
+Next meeting
+~~~~~~~~~~~~
+
+- Purpose of advisory board and its roles.
+- What are your priorities?
+- What is the threshold for your department to "pay" for service.
+- Outreach to find customers

--- a/rse/procedures/advisory-board.rst
+++ b/rse/procedures/advisory-board.rst
@@ -14,19 +14,19 @@ open on this page (though specific items may be retracted).
 Purpose of the advisory board
 -----------------------------
 
-The advisory board provides advice to the strategy and day to day
-implementation of the Aalto RSE program and its relation to scientific
-computing and teaching at Aalto.
+The advisory board provides advice to the strategy (and when relevant,
+day to day implementation) of the Aalto RSE program and its relation
+to research, scientific computing, and teaching at Aalto.
 
 
 
 Current advisory board
 ----------------------
 
-* SCI:
-* CS:
-* NBE:
-* PHYS:
+* ...
+* ...
+* ...
+* ...
 * ...
 * ...
 
@@ -41,7 +41,8 @@ located here, newest first.
 Next meeting
 ~~~~~~~~~~~~
 
-- Purpose of advisory board and its roles.
+- Purpose of advisory board and its roles.  How often to meet?
 - What are your priorities?
 - What is the threshold for your department to "pay" for service.
-- Outreach to find customers
+- How can we find customers?
+- How much do we focus on cost recovery, and how much on basic work?

--- a/rse/procedures/index.rst
+++ b/rse/procedures/index.rst
@@ -39,3 +39,5 @@ For ourselves
    time-tracking
    implementation
    job-descriptions
+   units-info
+   advisory-board

--- a/rse/procedures/units-info.rst
+++ b/rse/procedures/units-info.rst
@@ -2,7 +2,7 @@ Unit information
 ================
 
 This page describes the Aalto units which are supporting the RSE
-program and how they can their priorities.
+program and what their priorities are.
 
 
 
@@ -13,10 +13,10 @@ A unit joining and providing funding should first check the
 :doc:`implementation plan <implementation>` and then consider the
 following questions:
 
-- Do you want  monetary share to be reduced to zero (by accept
-  project funds) ←→ maintain some fraction of support for basic
-  services (short term, free-at-point-of-use projects to strategically
-  improve the quality of your research).
+- Do you want your monetary share to be reduced to zero (by accept
+  project funds wherever possible) ←→ or maintain some fraction of
+  time for basic services (short term, free-at-point-of-use assistance
+  to strategically improve the quality of your research).
 
 - Support the coolest projects ←→ help those who are struggling the
   most.
@@ -31,7 +31,7 @@ Units
 The following units are currently supporting the RSE program, so only
 these units may receive the "basic service" (short term help, free to
 the user).  Others *may* be able to purchase our services using their
-own project funding.
+own project funding, depending on how much time we have available.
 
 
 SCI
@@ -40,6 +40,7 @@ SCI
 
 CS
 ~~
+
 
 NBE
 ~~~

--- a/rse/procedures/units-info.rst
+++ b/rse/procedures/units-info.rst
@@ -1,0 +1,49 @@
+Unit information
+================
+
+This page describes the Aalto units which are supporting the RSE
+program and how they can their priorities.
+
+
+
+General questions
+-----------------
+
+A unit joining and providing funding should first check the
+:doc:`implementation plan <implementation>` and then consider the
+following questions:
+
+- Do you want  monetary share to be reduced to zero (by accept
+  project funds) ←→ maintain some fraction of support for basic
+  services (short term, free-at-point-of-use projects to strategically
+  improve the quality of your research).
+
+- Support the coolest projects ←→ help those who are struggling the
+  most.
+
+- Contact us for a personalized chat about possibilities.
+
+
+
+Units
+-----
+
+The following units are currently supporting the RSE program, so only
+these units may receive the "basic service" (short term help, free to
+the user).  Others *may* be able to purchase our services using their
+own project funding.
+
+
+SCI
+~~~
+
+
+CS
+~~
+
+NBE
+~~~
+
+
+PHYS
+~~~~


### PR DESCRIPTION
- Add two new pages, to be updated later.
  - Advisory board: a group that steers the program.  This page
    contains it's composition and meetings.
  - Units: tracks which units are currently members and provide basic
    services for their researchers.
- Review: general sanity check