### PR TITLE
rse/how-we-work: Add link to the A4 DMP template

### DIFF
--- a/rse/how-we-work.rst
+++ b/rse/how-we-work.rst
@@ -60,6 +60,9 @@ job helping you.
   scientific background in advance, so
   that they can be browsed.  The more we know in advance, the better
   we can estimate the time required and how to best help you.
+* How do you manage your data?  To map things out, consider `this
+  one-page data management plan table
+  <https://drive.google.com/drive/folders/0BzlGN0F6ew2hc0hGVXVTaGZwQjQ>`__.
 * Final outputs, location, publication.
 * Time frame and schedule flexibility.
 


### PR DESCRIPTION
- I made this myself, and I hope it's fast enough to get a quick
  overview of a project's data processing, without being too
  bureaucratic.
- Of course this doesn't apply to every project, but for those that we
  do, it seems relevant.
- Review: is this a good idea?  Is there some other option?