### PR TITLE
rse/request: Remove Gitlab mention

### DIFF
--- a/rse/request.rst
+++ b/rse/request.rst
@@ -34,19 +34,130 @@ You can request an initial consultation or submit a project request via Gitlab i
 Use these direct links to select the template (on the version.aalto.fi login page,
 click the "sign in with HAKA" button):
 
-* `LINK: Request a
-  consultation <consultation_>`__: quick initial consultation
-* `LINK: Submit a new project request <new_project_>`__:
-  a more involved project that spans days, weeks, or more.
-* You can make the issue "confidential" so that others won't see (but
-  it may be shared internal to Aalto for prioritization and
-  reporting - don't submit confidential data), but we suggest that you 
-  don't make it confidential so that we can all learn from each other.
+..
+  * `LINK: Request a
+    consultation <consultation_>`__: quick initial consultation
+  * `LINK: Submit a new project request <new_project_>`__:
+    a more involved project that spans days, weeks, or more.
+  * You can make the issue "confidential" so that others won't see (but
+    it may be shared internal to Aalto for prioritization and
+    reporting - don't submit confidential data), but we suggest that you
+    don't make it confidential so that we can all learn from each other.
+
+You can request an initial consultation or submit a project request
+(really, it's not that different, since everything is read by a human)
+
+* Send an email to scicomp at aalto.fi.
 * You can come to our :doc:`daily garage </help/garage>` or contact us
   by email at scicomp at aalto.fi.
+* At the bottom of this page are some email templates you can copy to
+  make sure you provide the main information we need.
 
 .. _consultation: https://version.aalto.fi/gitlab/AaltoRSE/rse-projects/issues/new?issuable_template=consultation
 .. _new_project: https://version.aalto.fi/gitlab/AaltoRSE/rse-projects/issues/new?issuable_template=new_project
+
+Email templates
+---------------
+
+Request a consultation
+~~~~~~~~~~~~~~~~~~~~~~
+
+(smaller, start a discussion)
+
+::
+
+   ## Basics
+
+   **Main contact(s) (if you @-mention their username, they will get notified)**:
+
+   **Group**:
+
+   **Department**:
+
+   I'd like to talk for an hour or so (adjust to suit your needs)
+
+
+   ## About the project
+
+   (tell us about your project and what you would like to consult about.)
+
+
+
+
+
+   ## Links
+
+   Link to any code or existing documentation, which we can browse to
+   get:
+
+   * ...
+   * ...
+
+
+
+Submit a project
+~~~~~~~~~~~~~~~~
+
+(larger, you know what you want)
+
+::
+
+   ## Basics
+
+   **Main contact(s) (if you @-mention their username, they will get notified)**:
+
+
+   **Other people involved (if you @-mention their usernames, they will get
+   notified):**
+
+
+   **Group**:
+
+
+   **Department**:
+
+
+   **Basic description (1-3 sentences)**:
+
+
+   **Your estimate of time needed**:
+
+
+
+
+
+   ## About the project
+
+   **About your team, who is working on it now**:
+
+
+
+   **Tech tools you use or need**:
+
+
+
+   **How involved will you be**:
+
+
+
+   **What domain knowledge is needed?**:
+
+
+
+   **Strategic benefit to your group/department/Aalto**:
+
+
+
+
+
+   ## Links
+
+   Link to any code or existing documentation, which we can browse to
+   get:
+
+   * ...
+   * ...
+
 
 
 

--- a/rse/request.rst
+++ b/rse/request.rst
@@ -28,11 +28,13 @@ We recommend you come to our daily :ref:`garage sessions
 Contact links
 -------------
 
-Our email is scicomp at aalto.fi.
+..
+  Our email is scicomp at aalto.fi.
 
-You can request an initial consultation or submit a project request via Gitlab issues.
-Use these direct links to select the template (on the version.aalto.fi login page,
-click the "sign in with HAKA" button):
+..
+  You can request an initial consultation or submit a project request via Gitlab issues.
+  Use these direct links to select the template (on the version.aalto.fi login page,
+  click the "sign in with HAKA" button):
 
 ..
   * `LINK: Request a
@@ -47,9 +49,8 @@ click the "sign in with HAKA" button):
 You can request an initial consultation or submit a project request
 (really, it's not that different, since everything is read by a human)
 
-* Send an email to scicomp at aalto.fi.
-* You can come to our :doc:`daily garage </help/garage>` or contact us
-  by email at scicomp at aalto.fi.
+* You can send an email to scicomp at aalto.fi.
+* You can come to our :doc:`daily garage </help/garage>`.
 * At the bottom of this page are some email templates you can copy to
   make sure you provide the main information we need.
 

--- a/rse/request.rst
+++ b/rse/request.rst
@@ -25,11 +25,10 @@ We recommend you come to our daily :ref:`garage sessions
 <scicomp-garage>` for a short chat.
 
 
-Contact links
--------------
+Contact
+-------
 
-..
-  Our email is scicomp at aalto.fi.
+Our email is scicomp at aalto.fi.
 
 ..
   You can request an initial consultation or submit a project request via Gitlab issues.


### PR DESCRIPTION
- Since we made Gitlab private, the statement for how to contact us is
  wrong.
- Change it to focus on email, but don't fully remove the old stuff
  yet.
- Review: I'm making this so we can make it correct in the short term,
  but I'm not sure if we either keep this, revert the Gitlab change,
  or wait to recommend something else.