### PR TITLE
rse/procedures/time-tracking: Add proposal of semantic data format

### DIFF
--- a/rse/procedures/time-tracking.rst
+++ b/rse/procedures/time-tracking.rst
@@ -49,6 +49,34 @@ Gitlab commands:
   (project or basic), and state.
 
 
+
+Reporting
+---------
+
+RSEs should be able to produce tabular data matching this semantic
+model.  Each row should be one (project, day) work report.
+
+* **username** of the RSE
+* **unit** hosting the research (Aalto acronym: SCI, (CS, NBE, PHYS,
+  MS, DIEM), ARTS, BIZ, CHEM, ELEC, ENG)
+* **day** of work (YYYY-MM-DD)
+* **hours** of work on that day.
+* **funding**: ``project`` or ``basic`` funding - who is paying for
+  this project?  If ``project``, this implies that it was billed to
+  Halli.  If ``basic``, it's assumed that it was billed to the RSE
+  project and accounting will be done at the end of the year.
+* **project-id**: Issue number from Gitlab (optional? - or some other
+  ID?).  Note that, from Gitlab, project issue number can give us the
+  **unit**, but not the **funding** since most likely initial
+  consultations occur before Halli is set up, so can't be billed to
+  that.
+* **comment**
+
+Things do not have to be exact for every day, but when aggregated over
+months, it should asymptotically approach the right values.
+
+
+
 Other notes
 -----------
 


### PR DESCRIPTION
- Each RSE may find their own way to track time, but we need the data
  to be compatible, so that we can merge it together.
- Here, define a semantic data format that *can* be standardized, so
  that we expect each RSE to provide information that matches this, so
  that it can be merged with our data.
- Review: is this a useful format?  This is just my first thought.