### PR TITLE
rse/units: fix RST syntax, page heading is heading

### DIFF
--- a/rse/units.rst
+++ b/rse/units.rst
@@ -1,5 +1,5 @@
 For units such as departments
------------------------------
+=============================
 
 Our pilot is funded by departments and schools, and members of these
 units can receive the basic services free of charge (in accordance to


### PR DESCRIPTION
- Since title was not a higher level, all sections appeared in the
  table of contents.
- Review: does CI pass?