### PR TITLE
Add a blog functionality

### DIFF
--- a/blog/2020/12/hello-world.rst
+++ b/blog/2020/12/hello-world.rst
@@ -1,0 +1,13 @@
+:blogpost: true
+:date: 2020-12-19
+:author: Richard Darst, Test User
+:category: meta, blog
+
+..
+  :location: World
+  :language: English
+
+Hello, world
+============
+
+We are trying a blog.

--- a/blog/2020/12/test.rst
+++ b/blog/2020/12/test.rst
@@ -1,0 +1,8 @@
+:blogpost: true
+:date: 2020-12-20
+:author: Richard Darst
+:category:
+
+
+TITLE
+==================================================

--- a/blog/new.sh
+++ b/blog/new.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [ -z "$1" ] ; then
+    echo "usage: new.sh <post slug>"
+    exit 1
+fi
+
+base=$(dirname $0)
+slug="$1"
+output="$base/$(date +%Y/%m)/$slug.rst"
+
+
+mkdir -p "$base/$(date +%Y/%m)/"
+cp "$base/post.rst.template" "$output"
+
+sed -i s/YYYY-MM-DD/$(date +%Y-%m-%d)/ "$output"
+
+echo "$output"

--- a/blog/post.rst.template
+++ b/blog/post.rst.template
@@ -1,0 +1,8 @@
+:blogpost: true
+:date: YYYY-MM-DD
+:author: AUTHOR
+:category:
+
+
+TITLE
+==================================================

--- a/conf.py
+++ b/conf.py
@@ -34,6 +34,7 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.ifconfig',
     'sphinx.ext.mathjax',
+    'ablog',
 ]
 # I try to make these docs buildable even without any extra dependencies
 # (nothing other than what you can find in Ubuntu).  So, add these to
@@ -339,6 +340,16 @@ epub_author = 'Aalto Science-IT'
 # -- Own options -------------------------------------------------------
 
 mathjax_path = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML'
+
+# blog
+blog_baseurl = 'https://scicomp.aalto.fi/blog/'
+blog_feed_fulltext = True
+post_date_format = '%Y %b %d'
+blog_feed_length = 50
+html_sidebars = {
+    '**': ['localtoc.html'],
+    }
+
 
 # Following allows custom CSS to be included
 # https://github.com/rtfd/sphinx_rtd_theme/issues/117

--- a/index.rst
+++ b/index.rst
@@ -24,8 +24,10 @@ other friends.  :doc:`You can join us </about/join>`.
    aalto/welcomeresearchers
    aalto/welcomestudents
 
-News
-====
+
+
+News and blog
+=============
 .. include:: /news/index.rst
    :start-line: 3
    :end-line: 7
@@ -35,6 +37,11 @@ News
 
    news/index.rst
 
+.. postlist:: 5
+   :sort:
+   :excerpts:
+
+:ref:`Archive <blog-posts>`
 
 The Aalto environment
 =====================

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ sphinx_gitstamp
 # For the slurm lexer
 pygments>=2.4
 https://github.com/AaltoSciComp/sphinx_rtd_theme_ext_color_contrast/archive/master.zip
+ablog


### PR DESCRIPTION
- This uses ablog (https://ablog.readthedocs.io/), which seems to work
  OK but I think it is worth thinking about long-term maintanance that
  this adds to this site.  Should the blog be kept separate?
- There is a `blog/new.sh` script to automate making a new post.
- There are several test posts, which should be edited or removed
  before posting.
- I haven't done too much to try to integrate this into the main site:
  nothing on sidebar (is that wanted), the list on the main page could
  be adjusted some.
- Could this replace the existing "news" setup?
- Review:
  - Discuss questions above
  - Don't merge until there is some further discussion