### PR TITLE
Add sphinx-{lesson,tabs,copybutton,togglebutton} extensions

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -40,6 +40,10 @@ extensions = [
 # extensions only if they are importable:
 optional_modules = [
     'sphinx_rtd_theme_ext_color_contrast',
+    'sphinx-copybutton',
+    'sphinx-lesson.directives',
+    'sphinx-tabs',
+    'sphinx-togglebutton',
     ]
 if on_rtd or 'GITSTAMP' in os.environ:
     optional_modules.append('sphinx_gitstamp')

--- a/conf.py
+++ b/conf.py
@@ -40,10 +40,10 @@ extensions = [
 # extensions only if they are importable:
 optional_modules = [
     'sphinx_rtd_theme_ext_color_contrast',
-    'sphinx-copybutton',
-    'sphinx-lesson.directives',
-    'sphinx-tabs',
-    'sphinx-togglebutton',
+    'sphinx_copybutton',
+    'sphinx_lesson.directives',
+    'sphinx_tabs.tabs',
+    'sphinx_togglebutton',
     ]
 if on_rtd or 'GITSTAMP' in os.environ:
     optional_modules.append('sphinx_gitstamp')

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,7 @@ sphinx_gitstamp
 # For the slurm lexer
 pygments>=2.4
 https://github.com/AaltoSciComp/sphinx_rtd_theme_ext_color_contrast/archive/master.zip
+sphinx-copybutton
+sphinx-lesson
+sphinx-tabs
+sphinx-togglebutton


### PR DESCRIPTION
- These allow better buttons and tabs for exercises (and other places)
- Review:
  - general check
  - do we want to preserve the ability to build without any extensions
    installed?  Right now you can, and it will just degrade the output
    somehow.  Is an immediate hard error better?