### PR TITLE
triton/accounts: Add name of Triton account request form

### DIFF
--- a/triton/accounts.rst
+++ b/triton/accounts.rst
@@ -11,7 +11,8 @@ by a fairshare algorithm: members of departments and schools which
 provide direct funding have a greater share.
 
 Please use `the account request form
-<https://selfservice.esupport.aalto.fi/ssc/app#/order/2025/>`__ to
+<https://selfservice.esupport.aalto.fi/ssc/app#/order/2025/>`__
+("Triton: New user account") to
 request the account.
 (For future help, you should probably use our issue tracker: see the
 :doc:`help` page.)


### PR DESCRIPTION
- If you aren't already logged in to Aalto auth, following the link
  will lead you to the central self-service page, not the exact form.
- Add name of page to clarify for these peple.
- Review: quick read