### PR TITLE
triton/tut/parallel: Added better MPI examples

### DIFF
--- a/triton/examples/python/python_openmp/python_openmp.rst
+++ b/triton/examples/python/python_openmp/python_openmp.rst
@@ -18,7 +18,7 @@ One can run this example with ``srun``::
   wget https://raw.githubusercontent.com/AaltoSciComp/hpc-examples/master/python/python_openmp/python_openmp.py
   module load anaconda
   export OMP_PROC_BIND=true
-  srun --cpus-per-task=2 --mem=2G --time=00:15:00 python tensorflow_mnist.py
+  srun --cpus-per-task=2 --mem=2G --time=00:15:00 python python_openmp.py
 
 or with ``sbatch`` by submitting
 :download:`python_openmp.slrm<https://raw.githubusercontent.com/AaltoSciComp/hpc-examples/master/python/python_openmp/python_openmp.slrm>`:

--- a/triton/tut/parallel.rst
+++ b/triton/tut/parallel.rst
@@ -177,7 +177,6 @@ you should load the same compiler that you used for compiling the code.
 .. include:: /triton/examples/python/python_openmp/python_openmp.rst
 
 
-
 Message passing programs: MPI
 -----------------------------
 
@@ -212,30 +211,44 @@ For basic use of MPI programs, you will need to use the
 Running a typical MPI program
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+The following use ``hpc-examples`` from
+:ref:`the previous exercises <triton-tut-exercise-repo>`.
+
 Loading module::
 
+  # GCC + OpenMPI
   module load gcc/9.2.0      # GCC
   module load openmpi/3.1.4  # OpenMPI
 
+  # Intel compilers + Intel's MPI
+  module load intel-parallel-studio/cluster.2019.3-intelmpi
+
 Compiling the code (depending on module and language)::
 
-  mpifort  -O2 -g mpi_prog.f -o mpi_prog # OpenMPI   + Fortran code
-  mpicc    -O2 -g mpi_prog.c -o mpi_prog # OpenMPI   + C code
-  mpiifort -O2 -g mpi_prog.f -o mpi_prog # Intel MPI + Fortran code
-  mpiicc   -O2 -g mpi_prog.c -o mpi_prog # Intel MPI + C code
+  # OpenMPI
+  mpicc    -O2 -g hello_mpi.c -o hello_mpi # C code
+  mpifort  -O2 -g hello_mpi_fortran.f90 -o hello_mpi_fortran # Fortran code
+
+  # Intel MPI
+  mpiicc   -O2 -g hello_mpi.c -o hello_mpi # C code
+  mpiifort -O2 -g hello_mpi_fortran.f90 -o hello_mpi_fortran # Fortran code
+
+Running the program with srun (for testing)::
+
+  srun --time=00:05:00 --mem-per-cpu=200M --ntasks=4 ./hello_mpi
 
 Running an MPI code in the batch mode:
 
 .. code-block:: slurm
 
   #!/bin/bash
-  #SBATCH --time=04:00:00      # takes 4 hours all together
-  #SBATCH --mem-per-cpu=2000   # 2GB per process
-  #SBATCH --ntasks=16          # 16 processes
-  #SBATCH --constraint=avx     # run on nodes with AVX instructions
+  #SBATCH --time=00:05:00      # takes 5 minutes all together
+  #SBATCH --mem-per-cpu=200M   # 200MB per process
+  #SBATCH --ntasks=4           # 4 processes
+  #SBATCH --constraint=avx     # set constraint for processor architecture
 
   module load openmpi/3.1.4  # NOTE: should be the same as you used to compile the code
-  srun ./mpi_prog
+  srun ./hello_mpi
 
 Triton has multiple architectures around (12, 20, 24, 40 CPU cores per node),
 even though SLURM optimizes resources usage and allocate CPUs within one node,
@@ -254,21 +267,21 @@ Spreading MPI workers evenly
 In many cases you might require more than one node during your job's runtime.
 
 When this is the case, it is usually recommended to split the number of
-workers somewhat evenly among the workers. To do this, one can use
+workers somewhat evenly among the nodes. To do this, one can use
 ``-N N``/``--nodes=N`` and ``--ntasks-per-node=n``. For example, the previous example
 could be written as:
 
 .. code-block:: slurm
 
   #!/bin/bash
-  #SBATCH --time=04:00:00      # takes 4 hours all together
-  #SBATCH --mem-per-cpu=2000   # 2GB per process
+  #SBATCH --time=00:05:00      # takes 5 minutes all together
+  #SBATCH --mem-per-cpu=200M   # 200MB per process
   #SBATCH --nodes=2            # 2 nodes
-  #SBATCH --ntasks-per-node=8  # 8 processes per node * 2 nodes = 16 processes in total
-  #SBATCH --constraint=avx     # run on nodes with AVX instructions
+  #SBATCH --ntasks-per-node=2  # 2 processes per node * 2 nodes = 4 processes in total
+  #SBATCH --constraint=avx     # set constraint for processor architecture
 
   module load openmpi/3.1.4  # NOTE: should be the same as you used to compile the code
-  srun ./mpi_prog
+  srun ./hello_mpi
 
 This way the number of workers is distributed more evenly, which in turn
 reduces communication overhead between workers.


### PR DESCRIPTION
This PR fixes some of the parallel examples on our tutorial page. Especially the MPI examples.