### PR TITLE
triton/usage/quotas: Add a du command to check home quota

### DIFF
--- a/triton/usage/quotas.rst
+++ b/triton/usage/quotas.rst
@@ -17,11 +17,14 @@ scratch, so if you ever get a "disk quota exceeded" error, then read on.
 
 .. note::
 
-   To try a quick fix, you can:
+   To try a quick fix for scratch, you can:
      ``quotafix -gs --fix /path/to/the/directory``
 
    If that fixes something, and problem recurs, then:
      ``module load teflon``
+
+   To check your home directory usage, run
+      ``du -xh $HOME | sort -h``
 
 How quotas work
 ---------------

--- a/triton/usage/quotas.rst
+++ b/triton/usage/quotas.rst
@@ -17,14 +17,11 @@ scratch, so if you ever get a "disk quota exceeded" error, then read on.
 
 .. note::
 
-   To try a quick fix for scratch, you can:
-     ``quotafix -gs --fix /path/to/the/directory``
+   To try a quick fix for scratch, you can: ``quotafix -gs --fix /path/to/the/directory``
 
-   If that fixes something, and problem recurs, then:
-     ``module load teflon``
+   If that fixes something, and problem recurs, then: ``module load teflon``
 
-   To check your home directory usage, run
-      ``du -xh $HOME | sort -h``
+   To check your home directory usage, run: ``du -xh $HOME | sort -h``
 
 How quotas work
 ---------------


### PR DESCRIPTION
- This was missing, despite being one of the common commonds to run
  when checking quota.

- List this as a thing to check home quota, but not Lustre.  To
  prevent people from getting too creative and running on scratch
  without thinking about it.

- Review:

  - How else should this page be adapted for home quotas?