### PR TITLE
aalto/aaltodata: Mention that users must be removed from groups

### DIFF
--- a/aalto/aaltodata.rst
+++ b/aalto/aaltodata.rst
@@ -129,9 +129,11 @@ everyone in the group has access.
    the necessary information (see bottom of page).
 -  Each group has an owner, quota on filesystems, and some other
    metadata (see below).
--  Group membership is per-account, not tied to employment contracts.
-   If you want someone to lose access, you have to explicitly remove
-   them when done.
+-  Group membership is per-account, not tied to employment contracts
+   or HR group membership.
+   If you want someone to lose access to a group you manage, they have
+   to be explicitly removed by the same method they were added (asking
+   someone or self-service, see bottom of page).
 -  **To have a group created and storage space allocated**, see below.
 -  **To get added to a group**, see instructions below.
 -  To see your groups: use the ``groups`` command or

--- a/aalto/aaltodata.rst
+++ b/aalto/aaltodata.rst
@@ -126,9 +126,12 @@ everyone in the group has access.
       there are fixed multi-year projects, they can also get a group.
 
 -  Groups are managed by IT staff. To request a group, mail us with
-   the necessary information (see next point).
+   the necessary information (see bottom of page).
 -  Each group has an owner, quota on filesystems, and some other
-   metadata (see below),
+   metadata (see below).
+-  Group membership is per-account, not tied to employment contracts.
+   If you want someone to lose access, you have to explicitly remove
+   them when done.
 -  **To have a group created and storage space allocated**, see below.
 -  **To get added to a group**, see instructions below.
 -  To see your groups: use the ``groups`` command or


### PR DESCRIPTION
- Previously, it didn't mention that group membership remains after
  a possible employment contract ends.
- Review:
  - general read
  - Is there anywhere else this should be mentioned?  There is a lot
    of text and maybe the important parts are too hard to find.