### PR TITLE
triton/tut/parallel: fix highlighting by changing lexer to bash

### DIFF
--- a/triton/tut/parallel.rst
+++ b/triton/tut/parallel.rst
@@ -10,7 +10,7 @@ Parallel computing is what HPC is really all about: processing things on
 more than one processor at once. By now, you should have read all of the previous
 tutorials.
 
-.. highlight:: console
+.. highlight:: bash
 
 
 


### PR DESCRIPTION
- There was a persistent warning that should go away now
- Review: are there CI warnings?