### PR TITLE
aalto/jupyterhub-instructors: add link to Noteable docs

### DIFF
--- a/aalto/jupyterhub-instructors/index.rst
+++ b/aalto/jupyterhub-instructors/index.rst
@@ -32,6 +32,10 @@ JupyterHub for instructors
 More info
 ---------
 
+* The `Noteable <https://noteable.edina.ac.uk/>`__ is a commercial
+  service using nbgrader and has some good documentation:
+  https://noteable.edina.ac.uk/documentation/
+
 Contact: CS-IT via the guru alias guru @ cs dot aalto.fi (students,
 contact your course instructors first).
 


### PR DESCRIPTION
- These docs are good and this is a commercial service, could be
  useful to our instructors.
- Review: general check