### PR TITLE
rse/index: Update front paragraphs from aalto.fi pages

### DIFF
--- a/rse/how-we-work.rst
+++ b/rse/how-we-work.rst
@@ -1,15 +1,9 @@
 How we work
 ===========
 
-.. warning::
-
-   This page is still in draft form and being discussed and
-   developed.  See the note on the parent page.
-
-
 This page is mostly focused on how long-term scheduled projects, which
 are funded by the research groups themselves, work.
-**Long-term tasks** are scheduled by fraction of full-time-equivalent
+**Long-term projects** are scheduled by fraction of full-time-equivalent
 (FTE) over weeks or months.
 
 For short-term code review tasks, come to any of our :doc:`garage
@@ -127,11 +121,19 @@ help design the system.
 Costs and time tracking
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-TODO
+Right now, most service is free for all users within the School of
+Science.
+
+TODO: future updates
 
 
 Funding practicalities
 ~~~~~~~~~~~~~~~~~~~~~~
+
+Right now, most service is free to all users in the School of
+Science.  In the future, longer-term projects can be funded by
+internal invoicing or directly hiring our RSE onto your grant, the
+same as salary of any researcher would work.
 
 TODO: This will be developed as we begin the program.  See above for a
 description.

--- a/rse/index.rst
+++ b/rse/index.rst
@@ -31,7 +31,7 @@ PHYS, and SCI overall.
 
 
 
-Using our services
+About our services
 ------------------
 
 .. toctree::
@@ -54,8 +54,8 @@ then :doc:`how to make a request <request>`.  When in doubt, come to
 .. toctree::
    :maxdepth: 1
 
-   how-we-work
    request
+   how-we-work
    group-leaders
 
 

--- a/rse/index.rst
+++ b/rse/index.rst
@@ -47,9 +47,7 @@ About our services
 How to get started
 ------------------
 
-**To get started,** first browse :doc:`how we work <how-we-work>` and
-then :doc:`how to make a request <request>`.  When in doubt, come to
-:doc:`the SciComp garage </help/garage>` or email scicomp at aalto.fi.
+Contact us as mentioned above, or read here for more details.
 
 .. toctree::
    :maxdepth: 1

--- a/rse/index.rst
+++ b/rse/index.rst
@@ -5,29 +5,21 @@ The Aalto `Research Software Engineers <rse-history_>`_ The Aalto
 Research Software Engineers (RSE) provide specialist support regarding
 software, computing, and data. As research becomes more digital and
 computer-dependent, the prerequisite knowledge grows larger and
-larger, creating a gap between those able to use the tools and those
-who struggle. The RSE program is designed to address this gap. We not
-only provide a service, but also teach researchers so they can be
-confident programmers and users of advanced IT tools, if that is their
-goal.
+larger, and we exist to help you fill that gap.
 
-We consist of experienced researchers who have relied heavily on
-computing technology (programming, computing, data) for our academic
-work, and thus can seamlessly collaborate on research projects. Our
-current mission is to use what we have learned to ensure that everyone
-can succeed in advanced research, regardless of pre-existing skills.
+Instead of hiring your own intern, postdoc, etc. to struggle with
+certain issues, we can help instead.  We consist of experienced
+researchers who have relied heavily on computing technology
+(programming, computing, data) for our academic work, and thus can
+seamlessly collaborate on research projects.  We can also do
+consultation and training.  You will have more
+impact since your work is more reusable, open, and higher quality.
 
 .. _rse-history: https://www.software.ac.uk/blog/2016-08-17-not-so-brief-history-research-software-engineers-0
 
-As a **researcher**, the RSE service will allow you to focus on what
-you want, the science, increase your impact by making your
-research outputs more reusable, open, and higher quality.  As a
-department, the RSE service will have an immense impact on your
-internal productivity.
-
-It's easy to request help, anywhere from an personal consultation, to
-group seminar and getting you on the right path, to work on a
-longer-term project.  Read more below.
+Departments can join this program and make this service to its
+community as a basic service.  Current member departments are CS, NBE,
+PHYS, and SCI overall.
 
 .. admonition:: Contact
 

--- a/rse/index.rst
+++ b/rse/index.rst
@@ -1,8 +1,8 @@
 Research Software Engineers
 ===========================
 
-The Aalto `Research Software Engineers <rse-history_>`_ The Aalto
-Research Software Engineers (RSE) provide specialist support regarding
+The Aalto `Research Software Engineers <rse-history_>`_ (RSEs) provide
+specialist support regarding
 software, computing, and data. As research becomes more digital and
 computer-dependent, the prerequisite knowledge grows larger and
 larger, and we exist to help you fill that gap.

--- a/rse/index.rst
+++ b/rse/index.rst
@@ -1,19 +1,28 @@
 Research Software Engineers
 ===========================
 
-Our `Research Software Engineer <rse-history_>`_ (RSE) service provides you with a
-dedicated specialist to assist you
-with computing, software, and data tasks in your research, for a longer
-period than other staff can.  Funding either comes from departments (for
-basic service) or from a research project.
+The Aalto `Research Software Engineers <rse-history_>`_ The Aalto
+Research Software Engineers (RSE) provide specialist support regarding
+software, computing, and data. As research becomes more digital and
+computer-dependent, the prerequisite knowledge grows larger and
+larger, creating a gap between those able to use the tools and those
+who struggle. The RSE program is designed to address this gap. We not
+only provide a service, but also teach researchers so they can be
+confident programmers and users of advanced IT tools, if that is their
+goal.
+
+We consist of experienced researchers who have relied heavily on
+computing technology (programming, computing, data) for our academic
+work, and thus can seamlessly collaborate on research projects. Our
+current mission is to use what we have learned to ensure that everyone
+can succeed in advanced research, regardless of pre-existing skills.
 
 .. _rse-history: https://www.software.ac.uk/blog/2016-08-17-not-so-brief-history-research-software-engineers-0
-
 
 As a **researcher**, the RSE service will allow you to focus on what
 you want, the science, increase your impact by making your
 research outputs more reusable, open, and higher quality.  As a
-department, the RSE service will have an immense impact on our
+department, the RSE service will have an immense impact on your
 internal productivity.
 
 It's easy to request help, anywhere from an personal consultation, to

--- a/rse/request.rst
+++ b/rse/request.rst
@@ -1,22 +1,9 @@
 Requesting RSE support
 ======================
 
-.. warning::
-
-   This page is still in draft form and being discussed and
-   developed.  See the note on the parent page.
-
-
-This page explains the typical process of contacting us and requesting
-RSE support.
-
-
-
-Medium or long-term, scheduled projects
----------------------------------------
-
-If you have a long-term project as part of a grant coming in the
-future, contact us to let us know and we can be prepared.
+You can contact us regardless of how small your issue is - or even if
+you would like to know if we could help your project.  At least, we
+can point you in the right direction.
 
 
 
@@ -24,25 +11,23 @@ Quick Consultations
 -------------------
 
 We recommend you come to our daily :ref:`garage sessions
-<scicomp-garage>` for a short chat.
+<scicomp-garage>` for a short chat.  There are no reservations, and
+this is the online equivalent of dropping by our office to say hi.
 
 
 
 Contact
 -------
 
-Our email is rse-group at aalto.fi (the Triton email address
-scicomp@aalto.fi also gets to us).
+Our email is rse-group@aalto.fi (the Triton email address
+scicomp@aalto.fi also gets to us).  Let us know what is going on, and
+we will find a good time to meet.
 
-You can request an initial consultation or submit a project request
-(really, it's not that different, since everything is read by a human):
-
-* You can send an email to rse-group at aalto.fi or use our `request
-  form <https://selfservice.esupport.aalto.fi/ssc/app#/order/2026/>`__
-  ("Research Software Engineer requst").  The email can be free-form, the request form guides you to answer
-  some useful questions.
-* You can come to our :doc:`daily garage </help/garage>` and have a
-  chat with us.
+You can also use the `structured request
+form <https://selfservice.esupport.aalto.fi/ssc/app#/order/2026/>`__
+("Research Software Engineer request").  This guides you through some
+of our initial questions, but goes to the same place as email and
+everything is read by a human anyway.
 
 
 


### PR DESCRIPTION
- Use our new text here
- Review:
  - Should it be made shorter?  I have tried before to make the intro
    text as short as possible, and this amount is making me think it's
    too long.
  - The aalto.fi text is designed to be very high-level.  I think this
    could be direct to the point, which would make it shorter as well.