### PR TITLE
Add some instructions for registering a new Zulip account

### DIFF
--- a/aalto/zulip.rst
+++ b/aalto/zulip.rst
@@ -6,7 +6,7 @@ Introduction
 ------------
 Zulip is an online discussion tool with latex support. It has been used by some Aalto teachers as an external service on individual courses. For Spring 2021, Zulip is provided by Aalto as a pilot solution for all School of Science departments' course needs. The pilot period covers teaching periods 3-5, so summer courses are not included. The pilot refers to a) a fixed-term project with clear lifecycle needs, like in courses which start and end at certain times. After the course has ended, the Zulip instance can be deleted. b) a transitional period between current state and possible production use or change to other solutions, and c) a basic solution with without all the fancy features or user interface. During the pilot users are expected to provide feedback, which will effect on the decision-making for future solutions, and the development of usability.
 
-CS-IT hosts `Zulip <https://zulipchat.com/>`_ the chat instances for you. These chat instances are hosted at ``<chat-name>.zulip.cs.aalto.fi``. Login to the chats is available with Aalto accounts. Email registration for external users is also possible via invitations.
+CS-IT hosts `Zulip <https://zulipchat.com/>`_ the chat instances for you. These chat instances are hosted at ``<chat-name>.zulip.cs.aalto.fi``. Login to the chats is available with Aalto accounts. Email registration for external users is also possible via invitations. After logging in for the first time with an Aalto account, if no matching Zulip account was found, you are prompted to "Register" and create one. Once the Zulip account has been created, it should be linked to your Aalto credentials.
 
 Internal or confidential matters should not be discussed on the platform.
 


### PR DESCRIPTION
There was some confusion from a new user as to what to do to login to scicomp.zulip.cs.aalto.fi: she could login with her Aalto account, but was then prompted to register for a Zulip account/profile, because no existing profile was found. I guess you should just register one and then the Zulip profileis linked to your Aalto credentials?