### PR TITLE
triton/usage/singularity: Remove outdated information 

### DIFF
--- a/triton/usage/singularity.rst
+++ b/triton/usage/singularity.rst
@@ -75,99 +75,101 @@ Singularity enables three base commands to user:
    What this means depends on the image in question. (see ``singularity
    run --help`` for more information on flags etc.)
 
+..
+    Commented until checked through
 
-Creating your own Singularity images to run in Triton
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Creating your own Singularity images to run in Triton
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-All images used in Triton are built from Docker images stored in
-our private Docker registry in
-`registry.cs.aalto.fi <https://registry.cs.aalto.fi>`_. They build
-automatically from Docker pushes using our continuous integration builder. If
-you want to build your own Singularity image to Triton, we can create a user
-for you to the registry and add your image to the automatic build.
+    All images used in Triton are built from Docker images stored in
+    our private Docker registry in
+    `registry.cs.aalto.fi <https://registry.cs.aalto.fi>`_. They build
+    automatically from Docker pushes using our continuous integration builder. If
+    you want to build your own Singularity image to Triton, we can create a user
+    for you to the registry and add your image to the automatic build.
 
-.. code-block:: none
+    .. code-block:: none
 
-  Even though the system is in production it is still being tested.
-  Thus there might be changes in the future.
+      Even though the system is in production it is still being tested.
+      Thus there might be changes in the future.
 
-Steps to get your images building are outlined below. You'll need to do steps
-1 to 3 only once.
+    Steps to get your images building are outlined below. You'll need to do steps
+    1 to 3 only once.
 
-Step 1: Log in to registry.cs.aalto.fi
---------------------------------------
+    Step 1: Log in to registry.cs.aalto.fi
+    --------------------------------------
 
-Go to
-`registry.cs.aalto.fi <https://registry.cs.aalto.fi>`_ and click ``Gitlab`` under
-``Social logins``. This will redirect you to a ``Gitlab`` page that you can use
-for authentication. In this page use your Aalto username and password to login.
+    Go to
+    `registry.cs.aalto.fi <https://registry.cs.aalto.fi>`_ and click ``Gitlab`` under
+    ``Social logins``. This will redirect you to a ``Gitlab`` page that you can use
+    for authentication. In this page use your Aalto username and password to login.
 
-In the future we'll improve the authentication page.
+    In the future we'll improve the authentication page.
 
-Step 2: Create an application token
------------------------------------
+    Step 2: Create an application token
+    -----------------------------------
 
-For added security you cannot use your main password for ``docker login``.
-By clicking on your username, you'll get to your user settings. From there, do
-the following:
+    For added security you cannot use your main password for ``docker login``.
+    By clicking on your username, you'll get to your user settings. From there, do
+    the following:
 
-  1. Click ``Create new token`` in the Application tokens-section.
-  2. Choose name for the token and click create.
-  3. Copy the application token that is visible on the right side of your
-     screen.
+      1. Click ``Create new token`` in the Application tokens-section.
+      2. Choose name for the token and click create.
+      3. Copy the application token that is visible on the right side of your
+         screen.
 
-Step 3: Docker login
---------------------
+    Step 3: Docker login
+    --------------------
 
-On your own workstation run::
+    On your own workstation run::
 
-  docker login registry.cs.aalto.fi
+      docker login registry.cs.aalto.fi
 
-Your username is same as your Aalto username. As a password give the
-application token you created in step 2.
+    Your username is same as your Aalto username. As a password give the
+    application token you created in step 2.
 
-Step 4: Push your images to registry
-------------------------------------
+    Step 4: Push your images to registry
+    ------------------------------------
 
-If you have an existing image in Dockerhub, you can run::
+    If you have an existing image in Dockerhub, you can run::
 
-  docker pull <dockerhub user>/<image>:<tag>
-  docker tag <dockerhub user>/<image>:<tag> registry.cs.aalto.fi/<your username>/<image>:<tag>
-  docker push registry.cs.aalto.fi/<your username>/<image>:<tag>
+      docker pull <dockerhub user>/<image>:<tag>
+      docker tag <dockerhub user>/<image>:<tag> registry.cs.aalto.fi/<your username>/<image>:<tag>
+      docker push registry.cs.aalto.fi/<your username>/<image>:<tag>
 
-For example::
+    For example::
 
-  docker pull library/ubuntu:latest
-  docker tag library/ubuntu:latest registry.cs.aalto.fi/$USER/ubuntu:latest
-  docker push registry.cs.aalto.fi/$USER/ubuntu:latest
+      docker pull library/ubuntu:latest
+      docker tag library/ubuntu:latest registry.cs.aalto.fi/$USER/ubuntu:latest
+      docker push registry.cs.aalto.fi/$USER/ubuntu:latest
 
-If you are building your image from Dockerfile, you can run::
+    If you are building your image from Dockerfile, you can run::
 
-  docker build -it registry.cs.aalto.fi/$USER/my_image:latest /path/to/my/dockerfile
-  docker push registry.cs.aalto.fi/$USER/my_image:latest
+      docker build -it registry.cs.aalto.fi/$USER/my_image:latest /path/to/my/dockerfile
+      docker push registry.cs.aalto.fi/$USER/my_image:latest
 
-Step 5: Let us know what image you want to have in Triton
----------------------------------------------------------
+    Step 5: Let us know what image you want to have in Triton
+    ---------------------------------------------------------
 
-.. warning::
-  Do note that images built to Triton are visible to all users.
-  Do not include sensitive code/data in the docker images. You should retreive
-  such data from your project/work folder during job runtime.
+    .. warning::
+      Do note that images built to Triton are visible to all users.
+      Do not include sensitive code/data in the docker images. You should retreive
+      such data from your project/work folder during job runtime.
 
-We need the following information for the automatic build:
+    We need the following information for the automatic build:
 
-  - What is the Docker url of the image
-    (e.g. ``registry.cs.aalto.fi/$USER/my_image``)?
-  - What tags do you want built (we recommend you use ``latest`` and ``dev``)?
-  - Does the image utilize GPUs?
+      - What is the Docker url of the image
+        (e.g. ``registry.cs.aalto.fi/$USER/my_image``)?
+      - What tags do you want built (we recommend you use ``latest`` and ``dev``)?
+      - Does the image utilize GPUs?
 
-After that we'll set up the automated build. Every time you push a newer
-version of said ``image:tag`` the image will update in Triton if the build
-was successful.
+    After that we'll set up the automated build. Every time you push a newer
+    version of said ``image:tag`` the image will update in Triton if the build
+    was successful.
 
-After the build has been done you can load up your new image in Triton with::
+    After the build has been done you can load up your new image in Triton with::
 
-  module use /share/apps/singularity-ci/centos/modules/$USER
-  module load my_image:latest
+      module use /share/apps/singularity-ci/centos/modules/$USER
+      module load my_image:latest
 
-and launch the programs within using the ``singularity_wrapper exec``.
+    and launch the programs within using the ``singularity_wrapper exec``.


### PR DESCRIPTION
This PR removes outdated information on automatic singularity image building until the document is up-to-date.