### PR TITLE
tech/index: Add two proposed talks by rkdarst

### DIFF
--- a/tech/index.rst
+++ b/tech/index.rst
@@ -61,16 +61,24 @@ Topics
 
   + Storage systems: hardware and software behind /scratch and /home, manitenance, troubleshooting techniques
 
+- Richard Darst
+
+  + Open and accessible documentation using Sphinx, RST/MyST, and Readthedocs
+
 - Simppa Äkäslompolo (?)
 
   + SLURM setup
 
-- Richard Darst 
+- Richard Darst
 
   + Jypiter setup at Aalto and best practices, ...
 
 - Simo/Mikko ?
 
   + Cluster monitoring
+
+- Richard Darst
+
+  - Online courses and CodeRefinery
 
 - add more here


### PR DESCRIPTION
- One: Sphinx documentation (should this be combined with the earlier
  general "support" talk?  I think that if we do, it would end up
  taking too long.)
- One: Online teaching practices and CodeRefinery
- Review: general read, this is dynamically updated as we make plans