### PR TITLE
index: Reduce the number of items on the sidebar

### DIFF
--- a/about/index.rst
+++ b/about/index.rst
@@ -1,5 +1,5 @@
-About Aalto Scientific Computing
-================================
+About
+=====
 
 Computational research is one of the focus areas in Aalto
 University, and **Aalto Scientific Computing** makes that possible.
@@ -214,3 +214,12 @@ Our users come from countless research areas:
 * Data mining
 * Deep learning and artificial intelligence
 * Big data analysis
+
+
+Other
+-----
+
+.. toctree::
+
+   web-accessibility
+   ../README

--- a/index.rst
+++ b/index.rst
@@ -147,8 +147,6 @@ About
 
    help/index
    about/index
-   about/web-accessibility
-   README
 
 These docs are open source: all content is licensed under CC-BY 4.0
 and all examples under CC0 (public domain).  Additionally, this is an


### PR DESCRIPTION
- Reduce items on sidebar, limit links on front page to those that are
  important.  The remaining links are put under the about/ section
  toctree (which is where I thought they could be anyway...)
- Rename "About ASC" to "About" to reflect bigger picture.
- Review: is this a good idea?