### PR TITLE
Switch all --mem units to M (instead of unspecified)

### DIFF
--- a/triton/apps/aims.rst
+++ b/triton/apps/aims.rst
@@ -35,7 +35,7 @@ To run FHI-aims on Triton a following example batch script can be used:
    #!/bin/bash -l
    #SBATCH --time=01:00:00
    #SBATCH --constraint=avx     # FHI-aims build requires at least AVX instrution set
-   #SBATCH  --mem-per-cpu=2000
+   #SBATCH  --mem-per-cpu=2000M
    #SBATCH --nodes=1
    #SBATCH --ntasks=24
 

--- a/triton/apps/matlab.rst
+++ b/triton/apps/matlab.rst
@@ -49,7 +49,7 @@ sample slurm script is provided underneath::
 
     #!/bin/bash -l
     #SBATCH --time=00:05:00
-    #SBATCH --mem=100
+    #SBATCH --mem=100M
     #SBATCH -o serial_Matlab.out
     module load matlab
     n=3
@@ -142,7 +142,7 @@ matslurm.sh::
 
     #!/bin/bash -l
     #SBATCH --time=00:05:00
-    #SBATCH --mem=500
+    #SBATCH --mem=500M
     #SBATCH -o job-%a.out
     #SBATCH --array=0-9
     module load matlab

--- a/triton/apps/vasp.rst
+++ b/triton/apps/vasp.rst
@@ -36,7 +36,7 @@ batch script
     #SBATCH --nodes=1
     #SBATCH --ntasks=8
     #SBATCH --time=06:00:00
-    #SBATCH --mem-per-cpu=1500
+    #SBATCH --mem-per-cpu=1500M
     ml vasp/5.4.4
     mpirun vasp_std
 
@@ -72,7 +72,7 @@ Example batch script
     #SBATCH --nodes=1
     #SBATCH --ntasks=8
     #SBATCH --time=06:00:00
-    #SBATCH --mem-per-cpu=1500
+    #SBATCH --mem-per-cpu=1500M
     module load vasp/5.4.1-gmvolf-triton-2016a
     srun vasp_std
 
@@ -110,7 +110,7 @@ contact triton support. Example job script below:
     #SBATCH --nodes=1
     #SBATCH --ntasks=12
     #SBATCH --time=06:00:00
-    #SBATCH --mem-per-cpu=2500
+    #SBATCH --mem-per-cpu=2500M
 
     module load vasp/5.3.5
 
@@ -139,7 +139,7 @@ be used, as the Opteron queue is often shorter. An example script below:
     #SBATCH --nodes=1
     #SBATCH --ntasks=12
     #SBATCH --time=06:00:00
-    #SBATCH --mem-per-cpu=2500
+    #SBATCH --mem-per-cpu=2500M
 
     module load vasp/5.3.3
 
@@ -159,7 +159,7 @@ newer above!):
     #SBATCH --nodes=1
     #SBATCH --ntasks=12
     #SBATCH --time=1-00:00:00
-    #SBATCH --mem-per-cpu=3500
+    #SBATCH --mem-per-cpu=3500M
 
     module load vasp/5.3.2
 

--- a/triton/examples/r/r_serial.slrm
+++ b/triton/examples/r/r_serial.slrm
@@ -1,7 +1,7 @@
 #!/bin/bash -l
 #SBATCH --time=00:05:00
 #SBATCH --ntasks=1
-#SBATCH --mem=100
+#SBATCH --mem=100M
 #SBATCH --output=r_serial.out
 
 module load r

--- a/triton/tut/array.rst
+++ b/triton/tut/array.rst
@@ -75,7 +75,7 @@ as you wish. Let's name it ``hello.sh`` and write it as follows.
    #SBATCH --output=/scratch/work/%u/task_number_%A_%a.out
    #SBATCH --array=0-15
    #SBATCH --time=00:15:00
-   #SBATCH --mem=200
+   #SBATCH --mem=200M
    # You may put the commands below:
 
    # Job step
@@ -163,7 +163,7 @@ a batch script is as follows.
    #SBATCH --open-mode=append
    #SBATCH --array=0-4
    #SBATCH --time=01:00:00
-   #SBATCH --mem=500
+   #SBATCH --mem=500M
    # Note that all jobs will write to the same file.  This makes less
    # files, but will be hard to tell the outputs apart.
 
@@ -217,7 +217,7 @@ Also note that the line numbers start at 1, not 0.
 
     #!/bin/bash
     #SBATCH --time=01:00:00
-    #SBATCH --mem=500
+    #SBATCH --mem=500M
     #SBATCH --output=pi.2.out.log
     #SBATCH --open-mode=append
     #SBATCH --array=1-4
@@ -253,7 +253,7 @@ definitely be worth your while.
 
    #!/bin/bash
    #SBATCH --time=01:00:00
-   #SBATCH --mem=500
+   #SBATCH --mem=500M
    #SBATCH --output=pi.3.out.log
    #SBATCH --open-mode=append
    #SBATCH --array=1-5

--- a/triton/tut/interactive.rst
+++ b/triton/tut/interactive.rst
@@ -112,7 +112,7 @@ resources available.
 For this, you just need srun's ``--pty`` option coupled with the shell
 you want::
 
-  srun -p interactive --time=2:00:00 --mem=600 --pty bash
+  srun -p interactive --time=2:00:00 --mem=600M --pty bash
 
 The command prompt will appear when the job starts.
 And you will have a bash shell runnnig on one of the
@@ -148,7 +148,7 @@ process again.
 
 ::
 
-     sinteractive --time=1:00:00 --mem=1000
+     sinteractive --time=1:00:00 --mem=1000M
 
 .. warning::
 

--- a/triton/tut/parallel.rst
+++ b/triton/tut/parallel.rst
@@ -165,7 +165,7 @@ Running an OpenMP code::
 
   export OMP_PROC_BIND=TRUE
   module load gcc/9.2.0
-  srun --cpus-per-task=4 --mem=500 --time=00:05:00 hello_omp
+  srun --cpus-per-task=4 --mem=500M --time=00:05:00 hello_omp
 
 The
 :download:`slurm script<https://raw.githubusercontent.com/AaltoSciComp/hpc-examples/master/openmp/hello_omp/hello_omp.slrm>`

--- a/triton/tut/serial.rst
+++ b/triton/tut/serial.rst
@@ -49,7 +49,7 @@ Let's take a look at the following script
 
    #!/bin/bash
    #SBATCH --time=00:05:00
-   #SBATCH --mem-per-cpu=100
+   #SBATCH --mem-per-cpu=100M
    #SBATCH --output=/scratch/work/%u/hello.%j.out
    #SBATCH --partition=debug
 

--- a/triton/usage/general.rst
+++ b/triton/usage/general.rst
@@ -107,7 +107,7 @@ Short batch example
 
     #!/bin/bash
     #SBATCH --time=04:00:00      # 4 hours
-    #SBATCH --mem=1000   # 1G of memory
+    #SBATCH --mem=1000M   # 1G of memory
 
     cd $WRKDIR/mydata/
     srun myprog params
@@ -136,7 +136,7 @@ and to generate output in a unique directory.
 
     #!/bin/bash
     #SBATCH --time=04:00:00
-    #SBATCH --mem-per-cpu=2500
+    #SBATCH --mem-per-cpu=2500M
     #SBATCH --array=0-29
      
     cd $SLURM_ARRAY_TASK_ID
@@ -188,7 +188,7 @@ OpenMP example
     #!/bin/bash
     #SBATCH --cpus-per-task=12
     #SBATCH --time=40:00
-    #SBATCH --mem-per-cpu=2000
+    #SBATCH --mem-per-cpu=2000M
     export OMP_PROC_BIND=true
     srun /path/to/openMP_executable
 
@@ -220,7 +220,7 @@ Small MPI example using mvapich2
     #SBATCH --nodes=1            # on one node
     #SBATCH --ntasks=4                 # 4 processes
     #SBATCH --time=4:00:00       # 4 hours
-    #SBATCH --mem-per-cpu=2000   # 2GB per process
+    #SBATCH --mem-per-cpu=2000M   # 2GB per process
      
     module load gmvolf/triton-2016a   # MVAPICH + GCC + math libs modules
     srun /path/to/mpi_program params
@@ -249,7 +249,7 @@ MPI example using Open MPI
 
     #!/bin/bash
     #SBATCH --time=2:00:00       # two hours job
-    #SBATCH --mem-per-cpu=1500   # 1.5GB of memory per process
+    #SBATCH --mem-per-cpu=1500M  # 1.5GB of memory per process
     #SBATCH --exclusive          # allocate whole node
     #SBATCH --constraint=hsw     # require Haswell CPUs with 24 cores per node 
     #SBATCH --nodes=2                 # on two nodes 
@@ -292,7 +292,7 @@ Hybrid MPI/OpenMP example using Open MPI
 
     #!/bin/bash
     #SBATCH --time=30:00
-    #SBATCH --mem-per-cpu=2500
+    #SBATCH --mem-per-cpu=2500M
     #SBATCH --exclusive
     #SBATCH --constraint=hsw    # Haswells only
     #SBATCH --ntasks=8          # -n, number of MPI tasks
@@ -315,7 +315,7 @@ Hybrid MPI/OpenMP example using mvapich2
 
     #!/bin/bash
     #SBATCH --time=30:00
-    #SBATCH --mem-per-cpu=2500
+    #SBATCH --mem-per-cpu=2500M
     #SBATCH --exclusive
     #SBATCH --constraint=[opt|wsm]
     #SBATCH --ntasks=8
@@ -346,7 +346,7 @@ Parallel job
 
     #!/bin/bash
     #SBATCH --time=00:01:00
-    #SBATCH --mem-per-cpu=500
+    #SBATCH --mem-per-cpu=500M
     #SBATCH --exclusive
     #SBATCH --constraint=[hsw|ivb|wsm]
     #SBATCH --nodes=4

--- a/triton/usage/localstorage.rst
+++ b/triton/usage/localstorage.rst
@@ -73,7 +73,7 @@ terminated (either because of ``scancel`` or due to time limit).
     #!/bin/bash
 
     #SBATCH --time=12:00:00
-    #SBATCH --mem-per-cpu=2500                                    # time and memory requirements
+    #SBATCH --mem-per-cpu=2500M                                   # time and memory requirements
 
     mkdir /tmp/$SLURM_JOB_ID                                      # get a directory where you will send all output from your program
     cd /tmp/$SLURM_JOB_ID
@@ -116,7 +116,7 @@ A sample code is below:
     #!/bin/bash
 
     #SBATCH --time=12:00:00
-    #SBATCH --mem-per-cpu=2000                        # time and memory requirements
+    #SBATCH --mem-per-cpu=2000M                       # time and memory requirements
     mkdir /tmp/$SLURM_JOB_ID                          # get a directory where you will put your data
     cp $WRKDIR/input.tar /tmp/$SLURM_JOB_ID           # copy tarred input files
     cd /tmp/$SLURM_JOB_ID


### PR DESCRIPTION
- Once in a garage, someone was confused about the default units.  An
  easy way to solve this is to always specific them.
- Add `M` as the dafult unit to every --mem and --mem-per-cpu, if not
  already specified.
- Found by clever grepping.
- Review
  - Do we want to do this?