### PR TITLE
University of Helsinki additions + various fixes.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,9 @@ Contributing gives agreement to use content under the licenses (CC-BY
 Requirements and building
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
+*Recommended*: Create new ``conda`` environment with ``conda create -n envname``. E.g ``conda create -n scicomp-docs -c conda-forge python pip``.  Switch to environment with ``conda activate envname`` and run ``python -m pip install -r requirements.txt``. 
+
+
 To build the docs, run ``make html``.  You can run ``make clean
 check`` to build it and report only the errors that would cause a
 failure.
@@ -51,7 +54,12 @@ dependencies to do basic tests is ``sphinx`` and ``sphinx_rtd_theme``
 (debian packages: ``python-sphinx`` and ``python-sphinx-rtd-theme``).
 
 HTML output is in ``_build/html/index.html``, and other output formats
-are available as well.
+are available as well. 
+
+.. To view built HTML output:
+.. - Linux ``xdg-open _build/html/index.html`` 
+.. - macOSX ``open _build/html/index.html``
+.. - Windows ``start _build/html/index.html``
 
 
 Editing

--- a/training/scip/summer-kickstart.rst
+++ b/training/scip/summer-kickstart.rst
@@ -170,8 +170,10 @@ resources.  All times are EEST (Helsinki) time.
     * Aalto: :doc:`Connecting to Triton tutorial
       </triton/tut/connecting>` – if you can ssh to Triton and run
       ``hostname``, you are ready for tomorrow.
-    * Helsinki: `general information <https://wiki.helsinki.fi/display/it4sci/HPC+SUMMER+KICKSTART+2021>`__
+    * Helsinki: `general information <https://wiki.helsinki.fi/display/it4sci/HPC+SUMMER+KICKSTART+2021>`__. To get started try ``ssh kale.grid.helsinki.fi``. You need to be on the UH network either through VPN (Activate HY-VPN 1 on Cubbli machine) or connected through ethernet on campus. **Note:** You can also connect via one of the universities `VDI <https://wiki.helsinki.fi/display/it4sci/HPC+SUMMER+KICKSTART+2021>`__ (Virtual desktop infrastructure). For example on your personal machine ``ssh username@pangolin.it.helsinki.fi`` then ``ssh kale.grid.helsinki.fi``
     * Tampere: `Connecting to Narvi <https://narvi-docs.readthedocs.io/narvi/tut/connecting.html>`__
+    * For information on using ``ssh`` go :doc:`here
+      </scicomp/ssh>`
 
 * **Day #2 (Tue 8.jun):** Basic use of a cluster (Richard Darst, Simo
   Tuomisto)

--- a/triton/examples/gpu/helloworld.cu
+++ b/triton/examples/gpu/helloworld.cu
@@ -1,0 +1,22 @@
+#include "stdio.h"
+
+__global__ void cuda_hello(int* a){
+        // blockIdx has values between 0 and 4
+        printf("Hello World from GPU a[%d]=%d \n", blockIdx.x, a[blockIdx.x]);
+}
+
+int main(void) {
+        int* d_a;
+
+        // Allocates an array of 5 integers
+        cudaMalloc(&d_a, 5*sizeof(int));
+
+        // Runs 5 instances of kernel cuda_hello in parallel
+        cuda_hello<<<5, 1>>>(d_a); 
+
+        // This is needed for the printf in the kernel to display
+        cudaDeviceSynchronize();
+
+        printf("Hello from outside GPU\n");
+        return 0;
+}

--- a/triton/examples/gpu/helloworld.sh
+++ b/triton/examples/gpu/helloworld.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#SBATCH --time=00:05:00
+#SBATCH --job-name=helloworld
+#SBATCH --mem-per-cpu=500M
+#SBATCH --cpus-per-task=1
+#SBATCH --gres=gpu:1
+#SBATCH --output=helloworld.out
+
+module load cuda
+# module load CUDA 
+nvcc helloworld.cu -o helloworld
+./helloworld

--- a/triton/examples/kale/hostname.slrm
+++ b/triton/examples/kale/hostname.slrm
@@ -1,0 +1,8 @@
+#!/bin/bash
+#SBATCH --time=00:05:00
+#SBATCH --mem-per-cpu=100M
+#SBATCH --partition=short
+#SBATCH --job-name=jobin_jake
+#SBATCH --output=/wrk/users/%u/host.%j
+
+srun hostname

--- a/triton/examples/pytorch/pytorch_mnist.rst
+++ b/triton/examples/pytorch/pytorch_mnist.rst
@@ -9,7 +9,7 @@ Let's run the MNIST example from
    :language: python
 
 The full code for the example is in
-:download:`tensorflow_mnist.py</triton/examples/pytorch/pytorch_mnist.py>`.
+:download:`pytorch_mnist.py</triton/examples/pytorch/pytorch_mnist.py>`.
 One can run this example with ``srun``::
 
   wget https://raw.githubusercontent.com/AaltoSciComp/scicomp-docs/master/triton/examples/pytorch/pytorch_mnist.py

--- a/triton/examples/tensorflow/tensorflow_mnist.rst
+++ b/triton/examples/tensorflow/tensorflow_mnist.rst
@@ -23,3 +23,5 @@ or with ``sbatch`` by submitting
    :language: slurm
 
 Do note that by default Keras downloads datasets to ``$HOME/.keras/datasets``.
+
+For users of Kale and Turso, Tensorflow requires the use of a virtual environment on the ``gpu`` node. You will be able to run the example through the default node but to run using ``--gres=gpu:1`` you need to set up a virtual environment. Instructions for setting one up can be found `here <https://wiki.helsinki.fi/display/it4sci/Module+System>`__, under *Virtual Environments*.

--- a/triton/help.rst
+++ b/triton/help.rst
@@ -9,6 +9,9 @@ tracker <issuetracker>`.
 Whatever you do, these `guidelines for making good support requests
 <https://research.csc.fi/support-request-howto>`__ are very useful.
 
+You can also see the `troubleshooting
+<troubleshooting>` page for solutions to common problems. 
+
 .. seealso::
 
    Are you just looking for a Triton account?  See :doc:`accounts`.
@@ -174,4 +177,3 @@ it to us/attach it to the bug report.
 If you use Python, add the ``-p`` option, matlab should use ``-m``,
 and graphical programs should use ``-x`` (these options have to go
 *before* the command you execute).
-

--- a/triton/index.rst
+++ b/triton/index.rst
@@ -33,6 +33,8 @@ Quick contents and links
 
        * :doc:`Quick Reference <ref/index>`
 
+       * :doc:`Troubleshooting <troubleshooting>`
+
        * Tutorials (start here)
 
 	 * :doc:`accounts`

--- a/triton/troubleshooting.rst
+++ b/triton/troubleshooting.rst
@@ -1,0 +1,17 @@
+Troubleshooting
+====
+
+Here is a list of common issues and errors you may come across when using Triton or your own cluster. 
+
+Common issues
+-----------------------
+
+``srun: Required node not available (down, drained or reserved)``
+#####
+
+
+This error usually occurs when the default specified node is down, drained or reserved which can happen if the cluster is undergoing some work. If this error occurs then the shell will usually hang after the job has been submitted if the job is still waiting for memory allocation. To find which nodes are available for us to run jobs we can use ``sinfo`` and under the ``STATE`` column you will see for each partition the states of the nodes. 
+
+To fix this we can either wait for the default node to be available or choose a different partition with the ``--partition=`` command, using one of the partitions from ``sinfo`` which has free and available (``idle``) nodes. 
+
+

--- a/triton/tut/gpu.rst
+++ b/triton/tut/gpu.rst
@@ -111,10 +111,39 @@ in the current directory:
    #SBATCH --cpus-per-task=1
    #SBATCH --gres=gpu:1
    #SBATCH --output=helloworld.out
+   #SBATCH --partition=gpu
 
    module load cuda
    nvcc helloworld.cu -o helloworld
    ./helloworld
+
+Using the :download:`helloworld.cu</triton/examples/gpu/helloworld.cu>`. 
+
+.. code-block:: slurm
+
+   #include "stdio.h"
+
+   __global__ void cuda_hello(int* a){
+           // blockIdx has values between 0 and 4
+           printf("Hello World from GPU a[%d]=%d \n", blockIdx.x, a[blockIdx.x]);
+   }
+
+   int main(void) {
+           int* d_a;
+
+           // Allocates an array of 5 integers
+           cudaMalloc(&d_a, 5*sizeof(int));
+
+           // Runs 5 instances of kernel cuda_hello in parallel
+           cuda_hello<<<5, 1>>>(d_a); 
+
+           // This is needed for the printf in the kernel to display
+           cudaDeviceSynchronize();
+
+           printf("Hello from outside GPU\n");
+           return 0;
+   }
+
 
 .. note::
 
@@ -123,7 +152,9 @@ in the current directory:
    program on a node without a GPU.  This especially happens if you try
    to test GPU code on the login node, and happens (for example) even if
    you try to import the GPU ``tensorflow`` module in Python on the login
-   node.
+   node. 
+
+   You may also need to use ``module load CUDA``. The ``gpu`` partition will be cluster specific and can also be used as a command line argument. 
 
 
 

--- a/triton/tut/interactive.rst
+++ b/triton/tut/interactive.rst
@@ -44,7 +44,7 @@ advanced way of submitting jobs, batch scripts.
      longer for their table, as a balancing mechanic.
 
    Thanks to `HPC Carpentry
-   <https://hpc-carpentry.github.io/hpc-intro/13-scheduler/index.html>`__
+   <https://carpentries-incubator.github.io/hpc-intro/13-scheduler/index.html>`__
    / `Sabry Razick <https://github.com/Sabryr>`__ for the idea.
 
 .. highlight:: console

--- a/triton/tut/interactive.rst
+++ b/triton/tut/interactive.rst
@@ -26,6 +26,8 @@ This tutorial walks you through running your jobs interactively.
 And in the next tutorial we will go through the more common and
 advanced way of submitting jobs, batch scripts.
 
+If you have any issues running the commands below (and in future) check out the :doc:`troubleshooting <../troubleshooting>` page!
+
 .. admonition:: An analogy: the HPC Diner
 
    You're eating out at the HPC Diner.  What happens when you arrive?
@@ -55,19 +57,32 @@ Your first interactive job
 
 Let's say you want to run the following command::
 
-    $ python3 -c 'import os; print("hi from", os.uname().nodename)'
+$ python3 -c 'import os; print("hi from", os.uname().nodename)'
 
-You can submit this program to Triton using ``srun``. All input/output still goes to your terminal
+
+You can submit this program to Triton using ``srun`` (remember to ``module load fgci-common`` and ``module load anaconda`` for python3). All input/output still goes to your terminal
 (but note that graphical applications don't work this way - see
-below)::
+below)
 
-    $ srun --mem=100M --time=1:00:00 python3 -c 'import os; print("hi from", os.uname().nodename)'
-    srun: job 52204499 queued and waiting for resources
+.. tabs::
+
+   .. code-tab:: bash Aalto
+
+         $ srun --mem=100M --time=1:00:00 python3 -c 'import os; print("hi from", os.uname().nodename)'
+        srun: job 52204499 queued and waiting for resources
+
+   .. code-tab:: bash Helsinki
+
+         $ srun --mem=100M --time=0:10:00 --partition=short python3 -c 'import os; print("hi from", os.uname().nodename)'
+        srun: job 52204499 queued and waiting for resources
+    
 
 Here, we are asking for 100 Megabytes of memory (``--mem=100M``) for a
 duration of an hour (``--time=1:00:00``).
 While your job - with **jobid** 52204499 - is waiting to be allocated resources, your shell
 effectively become non-interactive.
+
+**Note!** Some clusters such as kale at Helsinki won't allow a time of 1 hour (``--time=1:00:00``) so for this example it can be run with ``--time=0:10:00``. 
 
 You can open a new shell on triton and run the command ``slurm q`` to see all the jobs
 you have submitted to the queue::
@@ -86,11 +101,18 @@ You can see information such as the state, which partition the requested node re
   the process cancels and you have to run the ``srun`` command again.
 
 Once resources are allocated to your job, you see the name of the machine
-in the Triton cluster your program ran on, output to your terminal::
+in the Triton cluster your program ran on, output to your terminal
 
-  srun: job 52204499 has been allocated resources
-  hi from ivb17.int.triton.aalto.fi
+.. tabs::
 
+   .. code-tab:: bash Aalto
+
+           $ srun: job 52204499 has been allocated resources
+           hi from ivb17.int.triton.aalto.fi
+   .. code-tab:: bash Helsinki
+
+         $ srun: job 6098020 has been allocated resources
+         hi from kac07
 .. note::
 
    Interactive jobs are useful for debugging purposes, to test your setup
@@ -110,9 +132,17 @@ Put more precisely, you want access to a node in the cluster
 through an interactive bash shell that has all of the requested
 resources available.
 For this, you just need srun's ``--pty`` option coupled with the shell
-you want::
+you want
 
-  srun -p interactive --time=2:00:00 --mem=600M --pty bash
+.. tabs::
+
+   .. code-tab:: bash Aalto
+
+           $ srun -p interactive --time=2:00:00 --mem=600M --pty bash
+
+   .. code-tab:: bash Helsinki
+
+         $ srun -p test --time=00:10:00 --mem=100M --pty bash
 
 The command prompt will appear when the job starts.
 And you will have a bash shell runnnig on one of the
@@ -162,6 +192,10 @@ process again.
   If you are off-campus, you might want to use https://vdi.aalto.fi as a
   virtual desktop to connect to Triton to run graphical programs.
   Otherwise, programs may run very slowly.
+
+.. note::
+
+  Helsinki ``sinteractive`` does not currently work on kale. 
 
 Monitoring your usage
 =====================

--- a/triton/tut/parallel.rst
+++ b/triton/tut/parallel.rst
@@ -241,6 +241,12 @@ Running the program with srun (for testing)::
 
   srun --time=00:05:00 --mem-per-cpu=200M --ntasks=4 ./hello_mpi
 
+Download the code with::
+
+  wget https://raw.githubusercontent.com/AaltoSciComp/hpc-examples/master/mpi/hello_mpi/hello_mpi.c
+  
+  wget https://raw.githubusercontent.com/AaltoSciComp/hpc-examples/master/mpi/hello_mpi_fortran/hello_mpi_fortran.f90
+
 Running an MPI code in the batch mode:
 
 .. code-block:: slurm

--- a/triton/tut/serial.rst
+++ b/triton/tut/serial.rst
@@ -52,7 +52,9 @@ Let's take a look at the following script
    #SBATCH --mem-per-cpu=100M
    #SBATCH --output=hello.out
 
-   srun echo "Hello $USER! You are on node $HOSTNAME"
+   srun echo "Hello $USER! You are on node $HOSTNAME. The time is $(date). "
+
+.. date added to check if submitting multiple times gives different outputs.
 
 Let's name it ``hello.sh`` (create a file using your editor of choice, e.g. ``nano``;
 write the script above and save it)
@@ -154,14 +156,29 @@ Examples include partitions assigned to debugging("debug" partition),
 batch processing("batch" partition), GPUs("gpu" partition), etc.
 
 Command ``sinfo -s`` lists a summary of the available partitions. For the sake
-of brevity, let's see the first 4 partitions::
+of brevity, let's see the first 4 partitions
 
-  $ sinfo -s | head -n 5
-  PARTITION     AVAIL  TIMELIMIT   NODES(A/I/O/T)  NODELIST
-  interactive      up 1-00:00:00          4/0/0/4  pe[4-7]
-  jupyter-long     up 10-00:00:0          4/0/0/4  pe[4-7]
-  jupyter-short    up 1-00:00:00          4/0/0/4  pe[4-7]
-  grid             up 3-00:00:00       29/18/1/48  pe[9-48,74-81]
+.. tabs::
+
+   .. code-tab:: bash Aalto
+
+           $ sinfo -s | head -n 5
+           PARTITION     AVAIL  TIMELIMIT   NODES(A/I/O/T)  NODELIST
+           interactive      up 1-00:00:00          4/0/0/4  pe[4-7]
+           jupyter-long     up 10-00:00:0          4/0/0/4  pe[4-7]
+           jupyter-short    up 1-00:00:00          4/0/0/4  pe[4-7]
+           grid             up 3-00:00:00       29/18/1/48  pe[9-48,74-81]
+
+   .. code-tab:: bash Helsinki
+
+         $ sinfo -s | head -n 5
+         PARTITION AVAIL  TIMELIMIT   NODES(A/I/O/T)  NODELIST
+         short        up 1-00:00:00        31/4/7/42  kac[02-19],kam01,kas[01-23]
+         medium       up 7-00:00:00        24/0/2/26  kac[02-08],kas[05-23]
+         long         up 14-00:00:0        13/0/1/14  kas[01-04,14-23]
+         test*        up      10:00          0/0/1/1  kag01
+
+  
 
 Take a look at the manpage using ``man sinfo`` for more details.
 


### PR DESCRIPTION
Added additions to the docs regarding the Summer HPC Kickstart 2021. Most of the changes are tweaks to allow examples to be used on the University of Helsinki's `kale` and `turso` clusters. This was done through Sphinx's rst code-tabs so there is still the original Triton version as well as versions of some of the examples which can be used on kale. 

I also added some new README instructions, using a `conda env`. There is also a commented out section on viewing the html builds for contribution, I wasn't sure if this was necessary. 

I added a troubleshooting page which can be expanded if added. This is mostly for viewers/students to catch their own errors and learn why it happened. This was useful because at the time a number of `kale` nodes were being drained, in particular the default nodes for using `srun`. 

There are also various miscellaneous changes such as typos, links not working and downloads not being present. 