### PR TITLE
triton/apps/python: Info about conda activate in shells

### DIFF
--- a/triton/apps/python.rst
+++ b/triton/apps/python.rst
@@ -215,6 +215,33 @@ A few notes about conda environments:
 -  Often the same goes for other python based modules. We have setup
    many modules that do use anaconda as a backend. So, if you know what
    you are doing this might work.
+-  If you need to activate an environment from a Slurm script,
+   remember to do ``source activate`` and not ``conda activate``.
+
+.. admonition:: ``conda init``, ``conda activate``, and ``source activate``
+   :class: toggle
+
+   We don't recommend doing ``conda init`` like many sources
+   recommend: this will *permanently* affect your ``.bashrc`` file and
+   make hard-to-debug problems later.  The main points of ``conda
+   init`` are to a) automatically activate an environment (not good on
+   a cluster: make it explicit so it can be more easily debugged)
+   and b) make ``conda`` a shell function (not command) so that
+   ``conda activate`` will work (``source activate`` works as well in
+   all cases, no confusion if others don't.)
+
+   - If you activate one environment from another, for example after
+     loading an anaconda module, do ``source activate ENV_NAME`` like
+     shown above (conda installation in the environment not needed).
+
+   - If you make your own standalone conda environments, install the
+     ``conda`` package in them, then...
+
+   - Activate a standalone environment with conda installed in it by
+     ``source PATH/TO/ENV_DIRECTORY/bin/activate`` (which incidentally
+     activates just that one session for conda).
+
+
 
 .. _virtualenv:
 


### PR DESCRIPTION
- In the issue, it was noticed that `conda activate` doesn't work in a
  batch script, since .bashrc isn't sourced.  Here, I comment a bit
  more about why we do `source activate`, hiding details in a toggle
  box.
- Triton issue #873
- Review: should the toggle box be removed since it is too verbose?