### PR TITLE
rse: add "project done" checklist

### DIFF
--- a/rse/checklists/project-done.rst
+++ b/rse/checklists/project-done.rst
@@ -16,10 +16,18 @@ Discuss with the researchers:
 Internal tasks:
 
 * Issue tracker:
+
   * ``/summary`` should contain a several sentence summary focused on the
     benefit to the community (this is used for final reports, etc)
-  * Confirm other metadata is correct ``/contact``, ``/supervisor`` contains
-    people who may get emails about the project later (and shouldn't
-    contain people who may be surprised about automated survey emails)
+  * Confirm other metadata is correct
+
+    * ``/contact``, ``/supervisor`` contains
+      people who may get emails about the project later (and shouldn't
+      contain people who may be surprised about automated survey
+      emails)
+    * ``/timesaved``
+    * Outputs ``/projects``, ``/publications``, ``/software``,
+      `/datasets``, ``/outputs``
+
 * Add it to the next meeting agenda, give report about what we learned
   from it

--- a/rse/checklists/project-done.rst
+++ b/rse/checklists/project-done.rst
@@ -27,7 +27,7 @@ Internal tasks:
       emails)
     * ``/timesaved``
     * Outputs ``/projects``, ``/publications``, ``/software``,
-      `/datasets``, ``/outputs``
+      ``/datasets``, ``/outputs``
 
 * Add it to the next meeting agenda, give report about what we learned
   from it

--- a/rse/checklists/project-done.rst
+++ b/rse/checklists/project-done.rst
@@ -1,0 +1,25 @@
+RSE project done
+================
+
+
+Discuss with the researchers:
+
+* Explicitly confirm with customers that we are ending our focus on
+  this project and won't do more until we hear from them again.
+* Confirm it is publicly released, licensed, everything is done (or
+  discuss what else might need to be done).
+* Discuss what to do if there are issues in the future - garage, issue
+  tracker, training courses.
+* Discuss what else may (or may not) need doing in the future.
+
+
+Internal tasks:
+
+* Issue tracker:
+  * ``/summary`` should contain a several sentence summary focused on the
+    benefit to the community (this is used for final reports, etc)
+  * Confirm other metadata is correct ``/contact``, ``/supervisor`` contains
+    people who may get emails about the project later (and shouldn't
+    contain people who may be surprised about automated survey emails)
+* Add it to the next meeting agenda, give report about what we learned
+  from it

--- a/rse/index.rst
+++ b/rse/index.rst
@@ -92,7 +92,10 @@ Checklists
    :maxdepth: 1
 
    checklists/python
+   checklists/project-done
+
    JOSS checklist (external) <https://joss.readthedocs.io/en/latest/review_checklist.html>
+
 
 
 Internal documents


### PR DESCRIPTION
- A new page to go over end-of-project matters
- Initial contents from RSE meeting
- Review: what else could be added?  I haven't thought that much about it.