### PR TITLE
Adjust Hands-on scicomp url to hands-on.coderefinery.org

### DIFF
--- a/rse/become-a-rse.rst
+++ b/rse/become-a-rse.rst
@@ -197,4 +197,4 @@ These resources may be interesting to support your career as an RSE:
 * The `Society of Research Software Engineering <https://society-rse.org/>`__
 * :ref:`HPC and Triton <tutorials>`
 
-.. _hosc: https://handsonscicomp.readthedocs.io/
+.. _hosc: https://hands-on.coderefinery.org/

--- a/training/index.rst
+++ b/training/index.rst
@@ -96,7 +96,7 @@ There is a lot to learn, and it all depends on each other.  How do you
 get started?
 
 Our training map `Hands-on Scientific Computing
-<https://handsonscicomp.readthedocs.io>`__ sorts the skills you need
+<https://hands-on.coderefinery.org>`__ sorts the skills you need
 by level and category, providing you a strategy to get started.
 
 .. image:: /images/levels.svg

--- a/training/scip/summer-kickstart.rst
+++ b/training/scip/summer-kickstart.rst
@@ -281,7 +281,7 @@ resources.  All times are EEST (Helsinki) time.
     development.
 
   * Look at `Hands-on Scientific Computing
-    <https://handsonscicomp.readthedocs.io>`__ for an online course to
+    <https://hands-on.coderefinery.org>`__ for an online course to
     either browse or take for credits.
 
   * `Cluster Etiquette (in Research Software Hour)

--- a/training/scip/summer-kickstart/future.rst
+++ b/training/scip/summer-kickstart/future.rst
@@ -59,7 +59,7 @@ There are lots of other courses to take.
   * "Web show" on assorted topics related to scientific computing
   * Informal and unplanned
 
-* Hands-on Scientific Computing: https://handsonscicomp.readthedocs.io
+* Hands-on Scientific Computing: https://hands-on.coderefinery.org
 
   * Online course (more like a roadmap) of the most important untaught
     skills.

--- a/training/scip/summer-kickstart/intro.rst
+++ b/training/scip/summer-kickstart/intro.rst
@@ -205,7 +205,7 @@ Credits
 - We don't assign credits for attending this course - we can't track
   attendance.
 - Use what you learn here in the online course Hands-on Scientific
-  Computing (https://handsonscicomp.readthedocs.io) to get credits.
+  Computing (https://hands-on.coderefinery.org) to get credits.
 
 
 Join us!

--- a/triton/accounts.rst
+++ b/triton/accounts.rst
@@ -28,7 +28,7 @@ A few prerequisites:
 -  You should have enough background to use Triton well, including
    Linux skills.  Read
    `hands-on scientific computing
-   <https://handsonscicomp.readthedocs.io/en/latest/>`__, and you
+   <https://hands-on.coderefinery.org/>`__, and you
    should know A ("Basics"), C ("Linux"), and D ("HPC") well.  Also
    see the :ref:`Triton tutorials <tutorials>`.
 

--- a/triton/index.rst
+++ b/triton/index.rst
@@ -119,9 +119,9 @@ also know the `Basics (A) <hosc-a_>`__ and `Linux (C) <hosc-c_>`__
 levels as a prerequisite.
 
 .. _tutorial-playlist: https://www.youtube.com/playlist?list=PLZLVmS9rf3nN_tMPgqoUQac9bTjZw8JYc
-.. _hosc: https://handsonscicomp.readthedocs.io/en/latest/
-.. _hosc-a: https://handsonscicomp.readthedocs.io/en/latest/#a-basics
-.. _hosc-c: https://handsonscicomp.readthedocs.io/en/latest/#c-linux-and-shell
+.. _hosc: https://hands-on.coderefinery.org/
+.. _hosc-a: https://hands-on.coderefinery.org/#a-basics
+.. _hosc-c: https://hands-on.coderefinery.org/#c-linux-and-shell
 
 .. toctree::
    :maxdepth: 1

--- a/triton/tut/intro.rst
+++ b/triton/tut/intro.rst
@@ -63,14 +63,14 @@ need more knowledge to use Triton than most people learn in academic
 courses.
 
 Science-IT has created a (still under development) `modular
-training plan <https://handsonscicomp.readthedocs.io>`__, which
+training plan <https://hands-on.coderefinery.org>`__, which
 divides useful knowledge into levels.  In order to use Triton well, you need to be somewhat
 proficient at Linux usage (C level).  In order to do parallel work,
 you need to be good at the D-level and also somewhat proficient at the
 HPC level (E-level).  This tutorial and user guide covers the D-level,
 but it is up to you to reach the C-level first.
 
-See our `training program and plan <https://handsonscicomp.readthedocs.io>`__ for
+See our `training program and plan <https://hands-on.coderefinery.org>`__ for
 suggested material for self-study and lessons.  We offer routine
 training, see our :doc:`Scientific Computing in Practice lecture series
 </training/scip/index>` page for info.


### PR DESCRIPTION
- Based on our new location