### PR TITLE
Adding sftp-mounting to storage tutorial

### DIFF
--- a/triton/tut/storage.rst
+++ b/triton/tut/storage.rst
@@ -300,7 +300,7 @@ Easiest is to set up your ssh config (``.ssh/config``) on your machine as follow
         ProxyJump kosh    
 
 
-Instead of ``kosh``, you can also use ``taltta`` or any other shell server (see :doc:`Remote Access <../../aalto/remoteaccess/#linux-shell-servers>`) as a proxy to jump the firewall.
+Instead of ``kosh``, you can also use ``taltta`` or any other shell server (see :doc:`Remote Access <../../aalto/remoteaccess>`) as a proxy to jump the firewall.
 You can now open a graphic file manager that supports the sftp protocol (e.g. Files on Aalto Linux), and open:
 
 ``sftp://triton_via_kosh``

--- a/triton/tut/storage.rst
+++ b/triton/tut/storage.rst
@@ -288,14 +288,15 @@ You can use sftp and one of the shell servers to mount triton directly to your m
 Easiest is to set up your ssh config (.ssh/config) on your machine as follows (replace username by your username):
 
 ::
+
     Host kosh
-	User username
-	Hostname kosh.aalto.fi
+        User username
+        Hostname kosh.aalto.fi
     	
     Host triton_via_kosh	
-    	User username
-    	Hostname triton.aalto.fi
-    	ProxyJump kosh    
+        User username
+        Hostname triton.aalto.fi
+        ProxyJump kosh    
 
 You can now open a graphic file manager that supports the sftp protocol (e.g. `Files` on Aalto Linux), and open:
 

--- a/triton/tut/storage.rst
+++ b/triton/tut/storage.rst
@@ -287,7 +287,6 @@ Remote mounting using SFTP (Linux and Mac)
 You can use sftp and one of the shell servers to mount triton directly to your machine.
 Easiest is to set up your ssh config (.ssh/config) on your machine as follows (replace username by your username):
 
-``
     Host kosh
 	User username
 	Hostname kosh.aalto.fi
@@ -296,25 +295,22 @@ Easiest is to set up your ssh config (.ssh/config) on your machine as follows (r
     	User username
     	Hostname triton.aalto.fi
     	ProxyJump kosh    
-``
 
 You can now open a graphic file manager that supports the sftp protocol (e.g. `Files` on Aalto Linux), and open:
 
-```
-sftp://triton_via_kosh
-```
+``sftp://triton_via_kosh``
+
 
 which will direct you to the root folder of triton. To access scratch use:
 
-```
-sftp://triton_via_kosh/scratch
-```
+
+``sftp://triton_via_kosh/scratch``
+
 
 And to access your home folder use:
 
-```
-sftp://triton_via_kosh/home/username
-```
+``sftp://triton_via_kosh/home/username``
+
 
 
 

--- a/triton/tut/storage.rst
+++ b/triton/tut/storage.rst
@@ -299,6 +299,8 @@ Easiest is to set up your ssh config (``.ssh/config``) on your machine as follow
         Hostname triton.aalto.fi
         ProxyJump kosh    
 
+
+Instead of ``kosh``, you can also use ``taltta`` or any other shell server (see :doc:`Remote Access <../../aalto/remoteaccess/#linux-shell-servers>`) as a proxy to jump the firewall.
 You can now open a graphic file manager that supports the sftp protocol (e.g. Files on Aalto Linux), and open:
 
 ``sftp://triton_via_kosh``

--- a/triton/tut/storage.rst
+++ b/triton/tut/storage.rst
@@ -287,6 +287,7 @@ Remote mounting using SFTP (Linux and Mac)
 You can use sftp and one of the shell servers to mount triton directly to your machine.
 Easiest is to set up your ssh config (.ssh/config) on your machine as follows (replace username by your username):
 
+::
     Host kosh
 	User username
 	Hostname kosh.aalto.fi

--- a/triton/tut/storage.rst
+++ b/triton/tut/storage.rst
@@ -281,6 +281,42 @@ directly or ``AALTO\username``.
    section) to make your work as smooth as possible (or use
    vdi.aalto.fi, see below.
 
+Remote mounting using SFTP (Linux and Mac)
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can use sftp and one of the shell servers to mount triton directly to your machine.
+Easiest is to set up your ssh config (.ssh/config) on your machine as follows (replace username by your username):
+
+```
+    Host kosh
+	User username
+	Hostname kosh.aalto.fi
+    	
+    Host triton_via_kosh	
+    	User username
+    	Hostname triton.aalto.fi
+    	ProxyJump kosh    
+```
+
+You can now open a graphic file manager that supports the sftp protocol (e.g. `Files` on Aalto Linux), and open:
+
+```
+sftp://triton_via_kosh
+```
+
+which will direct you to the root folder of triton. To access scratch use:
+
+```
+sftp://triton_via_kosh/scratch
+```
+
+And to access your home folder use:
+
+```
+sftp://triton_via_kosh/home/username
+```
+
+
 
 Via `vdi.aalto.fi <https://vdi.aalto.fi>`__
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/triton/tut/storage.rst
+++ b/triton/tut/storage.rst
@@ -285,16 +285,16 @@ Remote mounting using SFTP (Linux and Mac)
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can use sftp and one of the shell servers to mount triton directly to your machine.
-Easiest is to set up your ssh config (.ssh/config) on your machine as follows (replace username by your username):
+Easiest is to set up your ssh config (.ssh/config) on your machine as follows (replace USERNAME by your username):
 
 ::
 
     Host kosh
-        User username
+        User USERNAME
         Hostname kosh.aalto.fi
     	
     Host triton_via_kosh	
-        User username
+        User USERNAME
         Hostname triton.aalto.fi
         ProxyJump kosh    
 
@@ -311,7 +311,7 @@ which will direct you to the root folder of triton. To access scratch use:
 
 And to access your home folder use:
 
-``sftp://triton_via_kosh/home/username``
+``sftp://triton_via_kosh/home/USERNAME``
 
 
 

--- a/triton/tut/storage.rst
+++ b/triton/tut/storage.rst
@@ -287,7 +287,7 @@ Remote mounting using SFTP (Linux and Mac)
 You can use sftp and one of the shell servers to mount triton directly to your machine.
 Easiest is to set up your ssh config (.ssh/config) on your machine as follows (replace username by your username):
 
-```
+``
     Host kosh
 	User username
 	Hostname kosh.aalto.fi
@@ -296,7 +296,7 @@ Easiest is to set up your ssh config (.ssh/config) on your machine as follows (r
     	User username
     	Hostname triton.aalto.fi
     	ProxyJump kosh    
-```
+``
 
 You can now open a graphic file manager that supports the sftp protocol (e.g. `Files` on Aalto Linux), and open:
 

--- a/triton/tut/storage.rst
+++ b/triton/tut/storage.rst
@@ -281,8 +281,9 @@ directly or ``AALTO\username``.
    section) to make your work as smooth as possible (or use
    vdi.aalto.fi, see below.
 
+
 Remote mounting using SFTP (Linux and Mac)
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can use sftp and one of the shell servers to mount triton directly to your machine.
 Easiest is to set up your ssh config (``.ssh/config``) on your machine as follows (replace ``USERNAME`` by your username):

--- a/triton/tut/storage.rst
+++ b/triton/tut/storage.rst
@@ -285,7 +285,7 @@ Remote mounting using SFTP (Linux and Mac)
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can use sftp and one of the shell servers to mount triton directly to your machine.
-Easiest is to set up your ssh config (.ssh/config) on your machine as follows (replace USERNAME by your username):
+Easiest is to set up your ssh config (``.ssh/config``) on your machine as follows (replace ``USERNAME`` by your username):
 
 ::
 

--- a/triton/tut/storage.rst
+++ b/triton/tut/storage.rst
@@ -298,7 +298,7 @@ Easiest is to set up your ssh config (``.ssh/config``) on your machine as follow
         Hostname triton.aalto.fi
         ProxyJump kosh    
 
-You can now open a graphic file manager that supports the sftp protocol (e.g. `Files` on Aalto Linux), and open:
+You can now open a graphic file manager that supports the sftp protocol (e.g. Files on Aalto Linux), and open:
 
 ``sftp://triton_via_kosh``
 


### PR DESCRIPTION
Adding another (potentially convenient) way of mounting triton filesyystems remotely using sftp and proxy jumps.
