### PR TITLE
triton/index: Move the reference/examples section higher

### DIFF
--- a/triton/index.rst
+++ b/triton/index.rst
@@ -108,15 +108,14 @@ Overview
    usagepolicy.rst
    acknowledgingtriton.rst
 
-.. _tutorials:
 
-Reference and Examples
-======================
+Quick reference
+===============
 .. toctree::
    :maxdepth: 1
 
    ref/index
-   examples/index
+
 
 Tutorials
 =========
@@ -148,16 +147,9 @@ levels as a prerequisite.
    tut/parallel.rst
    tut/dependency.rst
 
-Detailed instructions
-=====================
-.. toctree::
-   :maxdepth: 1
-   :glob:
-
-   usage/*
-
 .. _application-list:
 .. _apps:
+
 
 Applications
 ============
@@ -170,3 +162,23 @@ See our :doc:`general information <apps/index>` and the full list below:
 
    apps/index
    apps/*
+
+
+Examples
+========
+
+.. toctree::
+   :maxdepth: 1
+
+   examples/index
+
+.. _tutorials:
+
+
+Detailed instructions
+=====================
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   usage/*

--- a/triton/index.rst
+++ b/triton/index.rst
@@ -110,6 +110,14 @@ Overview
 
 .. _tutorials:
 
+Reference and Examples
+======================
+.. toctree::
+   :maxdepth: 1
+
+   ref/index
+   examples/index
+
 Tutorials
 =========
 These are designed to be read (or `watched <tutorial-playlist_>`__) in-order by every Triton user when they
@@ -162,12 +170,3 @@ See our :doc:`general information <apps/index>` and the full list below:
 
    apps/index
    apps/*
-
-
-Reference and Examples
-======================
-.. toctree::
-   :maxdepth: 1
-
-   ref/index
-   examples/index


### PR DESCRIPTION
- Learning by example is very important, and one complaint was that
  the docs are too tutorial-focused.
- Move this higher (even above tutorials) to empahsize it more.
- This may also motivate us to develop this section more.
- Review: general check
