### PR TITLE
training/scip/python-for-scicomp: Adjust community standards section

### DIFF
--- a/training/scip/python-for-scicomp.rst
+++ b/training/scip/python-for-scicomp.rst
@@ -110,26 +110,30 @@ Community standards
 -------------------
 
 This is a large course, and we will have many diverse groups attending
-it.  Everyone will be both a teacher and a learner and help to make
-the course successful.  Since this is a large and interactive course
-which we are just now prototyping, there will be some rough edges and
-not everything will go perfectly.  Please learn from our mistakes,
-too!
+it.  There will be people attending at all different levels, from
+"just learned Python" to "been using Python for a while and want to
+see some tips and tricks".  Everyone will choose their own path, some
+people will be more hands-on or more "watching".  Everyone is be both
+a teacher and a learner.  Even our instructors are always learning
+things and make mistakes (and this is part of the point!).  Please
+learn from our mistakes, too!
 
 This course consists of both lectures, hands-on exercises, and demos.
 It is designed to have a range of basic to advanced topics: there
 should be something for everyone.
 
-The main point this course is the exercises, and they will happen in
-breakout rooms where we expect people to work together and help each
+The main point this course is the exercises.  If you are with a group,
+we hope people to work together and help each
 other.  We expect everyone to help each other as best as they can with
 respect for different levels of knowledge - at the same time be aware
 of your own limitations.  No one is better than anyone else, we just
 have different existing skills and backgrounds.
 
-If there is anything wrong, *tell us* - if you need to contact us
-privately, you can message the host on Zoom or :doc:`contact us
-outside the course </help/index>`.  This could be as simple as "speak
+If there is anything wrong, *tell us* - HackMD is best.  If you need to contact us
+privately, you can message the host on Zoom, instructor chat is via
+`CodeRefinery chat <https://coderefinery.github.io/manuals/chat/>`__,
+and by email contact `CodeRefinery support
+<https://coderefinery.org/>`__. This could be as simple as "speak
 louder / text on screen is unreadable" or someone is creating a
 harmful learning environment.
 


### PR DESCRIPTION
- Has to be adjusted for livestream
- Add other private means of contact (chat, coderefinery support).
- Review:
  - read if the message is right?
  - are the contact methods good?
