### PR TITLE
Embed hpc-examples as a submodule

### DIFF
--- a/.github/workflows/checkwarnings.yaml
+++ b/.github/workflows/checkwarnings.yaml
@@ -15,6 +15,8 @@ jobs:
         python-version: [3.8]
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: recursive
       # https://github.com/actions/setup-python
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "_ext/sphinx_ext_minipres"]
 	path = _ext/sphinx_ext_minipres
 	url = https://github.com/rkdarst/sphinx_ext_minipres.git
+[submodule "triton/hpc-examples"]
+	path = triton/hpc-examples
+	url = git@github.com:AaltoSciComp/hpc-examples.git

--- a/triton/index.rst
+++ b/triton/index.rst
@@ -171,6 +171,7 @@ Examples
    :maxdepth: 1
 
    examples/index
+   hpc-examples/README
 
 .. _tutorials:
 


### PR DESCRIPTION
- Add the submodule at triton/hpc-examples.  This can co-exist with
  triton/examples for a while, until they are merged.

- Currently, hpc-examples is not well organized, via the sphinx site
  most of the examples can't be reached.  Doing so would seem to
  require that a lot of minimally-functional .rst pages are made to
  embed the code, which isn't great but would allow us to explain some
  more.  There are possibly other solutions that should be
  investigated.

- This could be merged now (minimally working, and improved later), or
  it could be left as a draft and we can figure some more things out
  before merging.
