### PR TITLE
Adding Info-Box for GPU jobs

### DIFF
--- a/triton/usage/gpu.rst
+++ b/triton/usage/gpu.rst
@@ -79,6 +79,14 @@ only difference is that they have nvidia kernel modules for Tesla cards.
 Running a GPU job in serial
 ---------------------------
 
+.. admonition:: Important note
+ 
+   When running a job using GPUs on the queue, be aware that you need to re-specify 
+   `` --gres=gpu:N`` in your function call if you run it via ``srun``. Otherwise the 
+   gpu will not be available for the run, since it was not reserved for the execution 
+   of the child-job.
+   
+   
 Quick interactive run::
 
     $ module load cuda

--- a/triton/usage/gpu.rst
+++ b/triton/usage/gpu.rst
@@ -81,7 +81,7 @@ Running a GPU job in serial
 
 .. admonition:: Important note
  
-   Update 2021-09: We recommond that you do **not** use `srun` within the job script
+   Update 2021-09: We recommond that you do **not** use ``srun`` within the job script
    for GPU jobs, since something has changed in the recent Slurm.  We are working
    on a permanent recommendation/solution.
 

--- a/triton/usage/gpu.rst
+++ b/triton/usage/gpu.rst
@@ -81,6 +81,10 @@ Running a GPU job in serial
 
 .. admonition:: Important note
  
+   Update 2021-09: We recommond that you do **not** use `srun` within the job script
+   for GPU jobs, since something has changed in the recent Slurm.  We are working
+   on a permanent recommendation/solution.
+
    When running a job using GPUs on the queue, be aware that you need to re-specify 
    `` --gres=gpu:N`` in your function call if you run it via ``srun``. Otherwise the 
    gpu will not be available for the run, since it was not reserved for the execution 


### PR DESCRIPTION
Adding an admonition to stress, that if submitting a job using srun (in a batch script) you need to re-request the GPU ressource.