### PR TITLE
Add generic instructions to all tutorial pages

### DIFF
--- a/triton/tut/applications.rst
+++ b/triton/tut/applications.rst
@@ -15,6 +15,12 @@ specifically talk about it.
 
    Main article: :doc:`../apps/index`
 
+.. admonition:: Generic instructions
+
+   * There are many ways to get software on Triton: we use the
+     standard module system, have Singularity containers, and you can
+     install your own.
+
 .. admonition:: Local differences
 
    Almost every site will use modules.  The exact module names, and

--- a/triton/tut/array.rst
+++ b/triton/tut/array.rst
@@ -6,6 +6,15 @@ Array jobs
 
    `Watch this in the Winter Kickstart 2021 course <https://www.youtube.com/watch?v=jcWoky9b8zI&list=PLZLVmS9rf3nN_tMPgqoUQac9bTjZw8JYc&index=16>`__
 
+.. admonition:: Generic instructions
+
+   * Arrays allow you to submit jobs and it runs many times with a
+     different ``$SLURM_ARRAY_TASK_ID`` environment variable.
+   * Submit with the ``--array=`` Slurm argument, give array indexes
+     like ``--array=1-10,12-15``.
+   * There are different templates to use below, you can adapt this to
+     your task.
+
 .. highlight:: console
 
 More often than not, scientific problems involve running a single program again

--- a/triton/tut/connecting.rst
+++ b/triton/tut/connecting.rst
@@ -18,18 +18,15 @@ way of doing this.
       to this material (and the tutorial in general).
 
 
-Summary:
+.. admonition:: Generic instructions
 
-You can connect to ``triton.aalto.fi`` via ssh from Aalto and CSC networks.
-Aalto networks include: Wired workstation networks, ``eduroam``, and
-the ``aalto`` wireless network *only if you are using an Aalto managed
-laptop* (otherwise ``aalto`` is like ``aalto open``).  If you connect
-to the Aalto VPN, you will be on the Aalto networks.
-
-For SSHing to Triton from outside of your department or CSC, please
-login first to a university server (like ``kosh.aalto.fi`` or
-``taltta.org.aalto.fi``) and then open a session to
-``triton.aalto.fi`` - or use the ``-J`` option in modern ssh.
+   * You can connect to Triton via ssh
+   * Host name is ``triton.aalto.fi``
+   * Connections available from the Aalto networks (VPN, most wired,
+     internal servers, ``eduroam``, ``aalto`` *only* if using an
+     Aalto-managed laptop, but *not* ``aalto open``),
+   * VPN is best but ``kosh.aalto.fi`` is a good ssh jump host from
+     outside (note the ``-J`` :doc:`ssh option </scicomp/ssh>`.
 
 .. important::
 

--- a/triton/tut/gpu.rst
+++ b/triton/tut/gpu.rst
@@ -6,6 +6,15 @@ GPU computing
 
    `Watch this in the Winter Kickstart 2021 course <https://www.youtube.com/watch?v=aoU1-5DjrGc&list=PLZLVmS9rf3nN_tMPgqoUQac9bTjZw8JYc&index=17>`__
 
+.. admonition:: Generic instructions
+
+   * Request a GPU with ``--gres=gpu:1``
+   * Don't use ``srun`` in your batch script, something is wrong right
+     now with Slurm.
+   * If you use Python, generally don't load your own CUDA module
+     unless you know you need this, install what you need through
+     anaconda.
+   * Monitor GPU performance with ``sacct -j <jobID> -o comment -p``.
 
 Introduction
 ------------

--- a/triton/tut/gpu.rst
+++ b/triton/tut/gpu.rst
@@ -9,8 +9,8 @@ GPU computing
 .. admonition:: Generic instructions
 
    * Request a GPU with ``--gres=gpu:1``
-   * Don't use ``srun`` in your batch script, something is wrong right
-     now with Slurm.
+   * Do not use ``srun`` in your batch script, there's a bug that
+     prevents job step's access to the GPU.
    * If you use Python, generally don't load your own CUDA module
      unless you know you need this, install what you need through
      anaconda.

--- a/triton/tut/interactive.rst
+++ b/triton/tut/interactive.rst
@@ -9,7 +9,7 @@ Interactive jobs
 .. admonition:: Generic instructions
 
    * We use the standard (and dominant) Slurm batch queuing system.
-   * See the :doc:`quick reference <../ref/>` for the reference you
+   * See the :doc:`quick reference <../ref/index>` for the reference you
      need if you know Slurm or batch systems.
    * For interactive testing, you can add ``srun [SLURM OPTIONS] COMMAND
      ...`` before any COMMAND to run it in Slurm.

--- a/triton/tut/interactive.rst
+++ b/triton/tut/interactive.rst
@@ -6,6 +6,17 @@ Interactive jobs
 
    `Watch this in the Winter Kickstart 2021 course <https://www.youtube.com/watch?v=xhX_u2OA89s&list=PLZLVmS9rf3nN_tMPgqoUQac9bTjZw8JYc&index=11>`__
 
+.. admonition:: Generic instructions
+
+   * We use the standard (and dominant) Slurm batch queuing system.
+   * See the :doc:`quick reference <../ref/>` for the reference you
+     need if you know Slurm or batch systems.
+   * For interactive testing, you can add ``srun [SLURM OPTIONS] COMMAND
+     ...`` before any COMMAND to run it in Slurm.
+   * ``sinteractive`` or ``srun --pty bash`` will get you shells in a
+     job environment.
+
+
 Introduction to Slurm
 =====================
 

--- a/triton/tut/modules.rst
+++ b/triton/tut/modules.rst
@@ -16,6 +16,17 @@ problem.  Software installation and management takes up a huge amount
 of our time, but we try to make it easy for our users.  Still, it can
 end up taking a lot of your effort as well.
 
+.. admonition:: Generic instructions
+
+   * We use the standard `Lmod module system
+     <https://lmod.readthedocs.io/>`__, which makes more software
+     available by adjusting environment variables like ``PATH``
+   * Search modules: ``module spider SEARCH_TERM``
+   * Load modules: ``module load MODULE_NAME``
+   * Unload modules: ``module unload MODULE_NAME``
+   * List currently loaded modules: ``module list``
+   * Reset modules to empty: ``module purge``
+
 .. admonition:: Local differences
 
    Almost every site uses modules, and most use the same Lmod system

--- a/triton/tut/monitoring.rst
+++ b/triton/tut/monitoring.rst
@@ -2,6 +2,18 @@
 Monitoring job progress and job efficiency
 ==========================================
 
+.. admonition:: Generic instructions
+
+   * You must always monitor jobs to make sure they are using all the
+     resources you request.
+   * Test scaling: double resources, if it doesn't run almost twice as
+     fast, it's not worth it.
+   * ``slurm queue`` shows waiting and running jobs (this is a custom command)
+   * ``slurm history`` shows completed jobs (also custom command)
+   * ``seff JOBID`` shows efficiency and performance of a single jobs
+   * GPU efficiency: A job's ``comment`` field shows GPU performance info
+     (custom setup), ``sacct -j JOBID -o comment -p`` shows this.
+
 Introduction
 ============
 

--- a/triton/tut/parallel.rst
+++ b/triton/tut/parallel.rst
@@ -10,6 +10,22 @@ Parallel computing is what HPC is really all about: processing things on
 more than one processor at once. By now, you should have read all of the previous
 tutorials.
 
+.. admonition:: Generic instructions
+
+   * You need to figure out what parallelization paradigm your program
+     uses, otherwise you won't know which options to use.
+
+     * Embarrassingly parallel: use array jobs.
+     * Multithreaded (OpenMP) or multiple tasks (like Python's
+       multiprocessing): ``--cpus-per-task=N``, ``--mem-per-core=M``
+       (if memory scales per CPU)
+     * MPI: compile to link with our Slurm and MPI libraries,
+       ``--ntasks=N``, always use ``srun`` to launch your job.
+       ``module load`` a MPI version for both compiling and running.
+
+   * You must always monitor jobs to make sure they are using all the
+     resources you request (``seff JOBID``).
+
 .. highlight:: bash
 
 

--- a/triton/tut/serial.rst
+++ b/triton/tut/serial.rst
@@ -22,7 +22,7 @@ Serial Jobs
 	module load anaconda
 	python my_script.py
 
-   * See the :doc:`quick reference <../ref/>` for more.
+   * See the :doc:`quick reference <../ref/index>` for more.
 
 
 Introduction to batch scripts

--- a/triton/tut/serial.rst
+++ b/triton/tut/serial.rst
@@ -6,6 +6,25 @@ Serial Jobs
 
    `Watch this in the Winter Kickstart 2021 course <https://www.youtube.com/watch?v=I79KLHb-7T0&list=PLZLVmS9rf3nN_tMPgqoUQac9bTjZw8JYc&index=14>`__
 
+.. admonition:: Generic instructions
+
+   * Batch scripts let you run work non-interactively, which is
+     important for scaling.
+
+   * Example batch script:
+
+     .. code:: slurm
+
+	#!/bin/bash -l
+	#SBATCH --time=01:00:00
+	#SBATCH --mem-per-cpu=1G
+
+	module load anaconda
+	python my_script.py
+
+   * See the :doc:`quick reference <../ref/>` for more.
+
+
 Introduction to batch scripts
 =============================
 

--- a/triton/tut/storage.rst
+++ b/triton/tut/storage.rst
@@ -18,6 +18,27 @@ This page roughly has three parts:
 - Where are they available (mounted) on Aalto computers?
 - How can you access them remotely?
 
+.. admonition:: Generic instructions
+
+   * We are a standard Linux filesystem
+
+     * ``$HOME`` = ``/home/$USER``: 10GB, backed up, not made larger
+     * Scratch is large but not backed up:
+
+       * ``$WRKDIR`` = ``/scratch/work/$USER``: Personal work directory
+       * ``/scratch/DEPARTMENT/NAME/``: Group-based shared directories
+         (recommended for most work, group leaders can request them)
+
+     * ``/tmp``: temporary directory, pre-user mounted in jobs and
+       automatically cleaned up.
+     * ``/l/``: local persistent storage on some group servers
+     * ``$XDG_RUNTIME_DIR``: ramfs on login node
+
+   * Data is also available from other places in Aalto, such as
+     desktop workstations, shell servers, and vdi.aalto.fi.  See below.
+
+   * Remote access available via ssh and SMB mounting on your own
+     computer (within Aalto networks)
 
 
 Basics


### PR DESCRIPTION
- Add the generic instructions at the top - suitable as a summary of
  content for new people, but the main use is that "someone who
  already knows everything except the content on the page can see what
  they need".  It is also good for people coming back to the page who
  just need to copy commands.

- Copy-paste templates could be added to several of the pages,
  possibly.  But then we can ask, should each template include what
  was introduced in previous pages?  I would say that for longer
  templates, peolpe can scan the page to find them.

- Review

  - Each one could should read to see what may be missing from there
    (but should be kept short with minimal examples) - I have not done
    a second reading yet.

  - Likewise, what should be removed from the generic instructions?

  - We could debate if this even needs to be here, instead of on the
    quick reference page (should people just look there?).  I think
    there is some more stuff that can be added to the quick reference
    (about examples and stuff), but "bottom line up front" is good for
    the individual pages, too.