### PR TITLE
minimum update for making the winter kickstart pages live

### DIFF
--- a/training/index.rst
+++ b/training/index.rst
@@ -25,9 +25,8 @@ and/or Python, Matlab, HTCondor and many others.
 .. toctree::
    :maxdepth: 1
 
-   scip/python-for-scicomp
-   scip/linux-shell-basics
-   scip/matlab-basics
+   scip/intro-linux-aalto-computing
+   scip/winter-kickstart
    scip/index
 
 .. toctree::

--- a/training/scip/index.rst
+++ b/training/scip/index.rst
@@ -35,7 +35,9 @@ Currently active (upcoming) courses have been moved to the
   - Matlab Advanced (May 2021, `materials <https://hackmd.io/@eglerean/MatlabAdvanced2021>`__)
   - Intro to Scientific Computing (June 2021)
   - Introduction to Julia (August 2021 & October 2021, `materials <https://github.com/AaltoRSE/julia-introduction>`__)
-
+  - Python for Scientific Computing (October 2021, `materials <https://aaltoscicomp.github.io/python-for-scicomp/>`__, `videos <https://www.youtube.com/playlist?list=PLZLVmS9rf3nOS7bHNmbcDoyTnMYaz_TJW>`__)
+  - Linux Shell Basics (November 2021, `materials <https://aaltoscicomp.github.io/linux-shell/>`__)
+  - Matlab Basics (November 2021, `materials <https://version.aalto.fi/gitlab/eglerean/matlabcourse/-/tree/master/AY20212022/MatlabBasics2021>`__)
 
 
 

--- a/training/scip/intro-linux-aalto-computing.rst
+++ b/training/scip/intro-linux-aalto-computing.rst
@@ -1,6 +1,12 @@
 =============================================
-Jan 2020 / Intro to Linux and Aalto Computing
+Jan 2022 / Intro to Linux and Aalto Computing
 =============================================
+
+.. admonition:: Page being updated
+
+   * This page is currently being updated. To register for the January 2022 sessions please visit https://link.webropol.com/s/introHPCJan2022
+
+
 
 .. admonition:: Quick links
 
@@ -83,7 +89,7 @@ the lectures.
 
 **Time, date, place:** (all times EET):
 
-- Friday, 29 January, online
+- Friday, 14 January 2022, online
 
   - Please connect 10 minutes early for icebreakers and introductions
 
@@ -111,10 +117,10 @@ the lectures.
 
 **Registration:**
 
-`Please register at this link <https://docs.google.com/forms/d/e/1FAIpQLScuBRlKQ4X-ZVSUhoz8zLYSgAI5xH91Cg9hfkEHrjmerViy0Q/viewform>`__
+`Please register at this link <https://link.webropol.com/s/introHPCJan2022>`__
 We aim to not require registration
 if you will be only passively watching.  Lurkers welcome.  Priority
-for Finnish academic institutions (FGCI members).
+for Finnish academic institutions (FCCI members).
 
 **Credits:** Certificates are not provided for this course.
 

--- a/training/scip/winter-kickstart.rst
+++ b/training/scip/winter-kickstart.rst
@@ -1,6 +1,11 @@
 ==================================
-Feb 2021 / Triton Winter Kickstart
+Jan 2022 / Triton Winter Kickstart
 ==================================
+
+.. admonition:: Page being updated
+
+   * This page is currently being updated. To register for the January 2022 sessions please visit https://link.webropol.com/s/introHPCJan2022
+
 
 .. admonition:: Quick Links
 
@@ -63,7 +68,7 @@ the course.
 
 **Registration:**
 
-`Please register at this link <https://docs.google.com/forms/d/e/1FAIpQLScuBRlKQ4X-ZVSUhoz8zLYSgAI5xH91Cg9hfkEHrjmerViy0Q/viewform>`__
+`Please register at this link <https://link.webropol.com/s/introHPCJan2022>`__
 
 **Instructors, organizers, contact:** For additional info, email scip@aalto.fi
 
@@ -72,16 +77,16 @@ the course.
 * Simo Tuomisto
 
 
-**Time, date, location:** Mon-Tue 1-2.February, 12:00-15:00.  Online,
+**Time, date, location:** Mon-Tue 17-18.January, 12:00-15:00.  Online,
 links sent to participants.
 
-- **Friday, 29 January, 2021**  (Zoom only, no Twitch)
+- **Friday, 14 January, 2022**  (Zoom only, no Twitch)
 
   - **14:00 -- 14:45**
   - Help connecting to Triton (Aalto), Zoom link by email to
     registered participants
 
-- **Monday, 1 February, 2021** (roughly connecting to serial jobs in
+- **Monday, 17 January, 2022** (roughly connecting to serial jobs in
   the :ref:`tutorials <tutorials>`)
 
   - **11:50 -- 15:00**, all times approximate, breaks every hour
@@ -94,7 +99,7 @@ links sent to participants.
   - :doc:`/triton/tut/interactive`
   - :doc:`/triton/tut/serial` (likely gets moved to day 3)
 
-- **Tuesday, 2 February, 2021**
+- **Tuesday, 18 January, 2022**
 
   - **11:50 -- 15:00**, all times approximate, breaks every hour
   - Likely


### PR DESCRIPTION
Registration links added and updated the dates. 

There is still "old" content that can be updated later.

Ideally one of the instructors can approve the PR