### PR TITLE
Remove next/previous buttons at the bottom of every page

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -154,6 +154,7 @@ else:
 #html_theme_options = {}
 html_theme_options = {
     'display_version': False,
+    'prev_next_buttons_location': 'none',
     #'navigation_depth': 3,
     #'canonical_url': 'https://scicomp.aalto.fi/'
     }


### PR DESCRIPTION
- Every page had these next/previous buttons, even though we weren't
  quite a forward-backwards thing.

- This PR comes because of something I noticed: in the tutorials, I
  added the page
  https:scicomp.aalto.fi/triton/tut/required-cluster-setup/ which is
  hidden in the toctree (mainly so that you can go up from that page
  to the tutorial), but not designed to go in the main flow (findable
  by 'next'/'prev').  The rest of the tutorials have explicit "this is
  the next lesson" text at the bottom.

- Most other pages still have no point for these buttons (if you want
  to see everything, you can just as well navigate to the next pages
  via the sidebar.  Though pages deep enough actually don't appear
  there, but I don't think that affects us right now).

- Review:

  - Does anyone want the next/previous buttons to stay?
