### PR TITLE
triton/usage/faq: notes about nodes not being available

### DIFF
--- a/triton/usage/faq.rst
+++ b/triton/usage/faq.rst
@@ -87,6 +87,12 @@ Job status and submission
        
       srun --time=1:00:00 ...
 
+.. collapse:: ``srun: Required node not available (down, drained or reserved)``
+
+   This error usually occurs when the default specified node is down, drained or reserved which can happen if the cluster is undergoing some work. If this error occurs then the shell will usually hang after the job has been submitted if the job is still waiting for memory allocation. To find which nodes are available for us to run jobs we can use ``sinfo`` and under the ``STATE`` column you will see for each partition the states of the nodes.
+
+   To fix this we can either wait for the default node to be available or choose a different partition with the ``--partition=`` command, using one of the partitions from ``sinfo`` which has free and available (``idle``) nodes.
+
 
 
 .. _FAQ_Accounts:

--- a/triton/usage/faq.rst
+++ b/triton/usage/faq.rst
@@ -87,6 +87,15 @@ Job status and submission
        
       srun --time=1:00:00 ...
 
+
+.. collapse:: ``srun: error: Unable to allocate resources: Requested node configuration is not available``
+
+   You have requested some Slurm options which do not include any
+   nodes (for example, asking for a GPU with ``--gres=gpu`` and a
+   partition without GPUs).  Figure out what the problem is and adjust
+   your Slurm options.
+
+
 .. collapse:: ``srun: Required node not available (down, drained or reserved)``
 
    This error usually occurs when a requested node is down, drained or reserved which can happen if the cluster is undergoing some work - and might happen if there are very few default nodes that Slurm chooses from. If this error occurs then the shell will usually hang after the job has been submitted if the job is still waiting for allocation. To find which nodes are available for us to run jobs we can use ``sinfo`` and under the ``STATE`` column you will see for each partition the states of the nodes.

--- a/triton/usage/faq.rst
+++ b/triton/usage/faq.rst
@@ -89,9 +89,9 @@ Job status and submission
 
 .. collapse:: ``srun: Required node not available (down, drained or reserved)``
 
-   This error usually occurs when the default specified node is down, drained or reserved which can happen if the cluster is undergoing some work. If this error occurs then the shell will usually hang after the job has been submitted if the job is still waiting for memory allocation. To find which nodes are available for us to run jobs we can use ``sinfo`` and under the ``STATE`` column you will see for each partition the states of the nodes.
+   This error usually occurs when a requested node is down, drained or reserved which can happen if the cluster is undergoing some work - and might happen if there are very few default nodes that Slurm chooses from. If this error occurs then the shell will usually hang after the job has been submitted if the job is still waiting for allocation. To find which nodes are available for us to run jobs we can use ``sinfo`` and under the ``STATE`` column you will see for each partition the states of the nodes.
 
-   To fix this we can either wait for the default node to be available or choose a different partition with the ``--partition=`` command, using one of the partitions from ``sinfo`` which has free and available (``idle``) nodes.
+   To fix this we can either wait for the node to be available or choose a different partition with the ``--partition=`` command, using one of the partitions from ``sinfo`` which has free and available (``idle``) nodes.
 
 
 


### PR DESCRIPTION
- Notes on the error messages
  `Unable to allocate resources: Requested node configuration is not available`
  and
  `Required node not available (down, drained or reserved)`

- This is based off of text originally by @JMuff22 - thanks!  This has
  a proper `Author:` credit which will be added to the git history,
  please approve the PR before we merge it.
