### PR TITLE
triton/usage/ood: Add OOD page with some basic information

### DIFF
--- a/triton/tut/connecting.rst
+++ b/triton/tut/connecting.rst
@@ -174,8 +174,9 @@ Connecting via Open onDemand
 
 OOD (Open onDemand) is a web-based user interface to Triton
 and a number of applications that utilize grafical user interface.
+:doc:`Read more about it on Triton <../usage/ood>`.
 
-Go to https://ood.triton.aalto.fi, login with your Aalto account. 
+Go to https://ood.triton.aalto.fi, login with your Aalto account.
 
 
 Connecting via JupyterHub

--- a/triton/usage/ood.rst
+++ b/triton/usage/ood.rst
@@ -1,0 +1,46 @@
+Open OnDemand
+=============
+
+.. warning::
+
+   Triton OOD is under development and is available as a preview/for
+   feedback.  It may or may not work at any given time as work on it.
+   It is probably best to use our :ref:`chat <chat>` to give quick
+   feedback.
+
+Open OnDemand is a web-based interface to computer clusters.  It
+provides a low-threshold way to do easy work and shell access to do
+more.  It complements, not replaces, the traditional ssh access: just
+like with Jupyter, it may help you get started, but most people will
+eventually move towards shell access (even if that shell is via Open
+OnDemand).
+
+
+
+How to use
+----------
+
+http://ood.triton.aalto.fi .  Log in with Aalto account.  You first
+get to the dashboard view, that provides file transfer and other
+services.
+
+
+
+Applications
+------------
+
+Once logged in, there are ways to start separate applications, for
+example Jupyter.  These run as separate, independent processes.
+
+We have these applications available and supported:
+
+* Jupyter
+* RStudio
+* ...
+
+
+Current issues
+--------------
+
+* Authentication will be updated.
+* Apps will be adjusted.


### PR DESCRIPTION
- Template of a basic docs page
- Mostly empty, to be filled out more later
- Review: general check, mostly merge + iterate
