### PR TITLE
Change conda on scratch to hidden folders

### DIFF
--- a/triton/apps/python.rst
+++ b/triton/apps/python.rst
@@ -169,13 +169,13 @@ result in running out of quota. To fix this, you should run the following comman
 
   module load miniconda
 
-  mkdir $WRKDIR/conda_pkgs
-  mkdir $WRKDIR/conda_envs
+  mkdir $WRKDIR/.conda_pkgs
+  mkdir $WRKDIR/.conda_envs
 
   conda config --append pkgs_dirs ~/.conda/pkgs
   conda config --append envs_dirs ~/.conda/envs
-  conda config --prepend pkgs_dirs $WRKDIR/conda_pkgs
-  conda config --prepend envs_dirs $WRKDIR/conda_envs
+  conda config --prepend pkgs_dirs $WRKDIR/.conda_pkgs
+  conda config --prepend envs_dirs $WRKDIR/.conda_envs
 
 **virtualenv** does not work with Anaconda, use ``conda`` instead.
 


### PR DESCRIPTION
At least to me, the conda environment/package folders being visible files is somewhat distracting, and I think "hiding" them on scratch (like they are in home) would make sense. This is just a suggestion though.