### PR TITLE
help/group-meetings: Add a page for group meetings

### DIFF
--- a/help/group-meetings.rst
+++ b/help/group-meetings.rst
@@ -1,0 +1,38 @@
+Periodic group meetings
+=======================
+
+We would like to meet with each research group once a year.  This
+isn't to advertise stuff to you, but to hear what you all need but
+can't get, so that we can help you with that.  A group meeting
+consists of your group plus a few members from technical services
+(Science-IT, CS-IT, etc.)  which are relevant for your group, and we
+here from you to guide our work.  Hopefully, we can immediately solve
+some of your major problems.
+
+
+
+Practical matters
+-----------------
+
+Ideally, someone (Science-IT, CS-IT, etc.) contacts your group leader
+to arrange a time.  In practice, this happens less frequently than
+yearly, since everyone is busy.  Internally, we work together, there
+is one meeting for all of the relevant support groups.
+
+On the other hand, **contact us anytime to arrange a group meeting** -
+we are always happy for an eager audience.
+
+The group meeting would happen whenever is most convenient for you -
+for example, during your regular group meetings.
+
+
+
+Topics
+------
+
+* Reminder of services available at Aalto and your department (short)
+* Latest changes or improvements (short))
+* Feedback: How do you do your work now?  What works well?  What
+  doesn't work well?  What do you need in the future?  **Tell us all
+  your complaints, without them, how can we work on the right
+  things?** (long)

--- a/help/group-meetings.rst
+++ b/help/group-meetings.rst
@@ -1,6 +1,9 @@
 Periodic group meetings
 =======================
 
+This page applies to these departments so far: **CS, NBE, PHYS** (if
+others want to join, let us know).
+
 We would like to meet with each research group once a year.  This
 isn't to advertise stuff to you, but to hear what you all need but
 can't get, so that we can help you with that.  A group meeting
@@ -15,15 +18,19 @@ Practical matters
 -----------------
 
 Ideally, someone (Science-IT, CS-IT, etc.) contacts your group leader
-to arrange a time.  In practice, this happens less frequently than
-yearly, since everyone is busy.  Internally, we work together, there
-is one meeting for all of the relevant support groups.
-
-On the other hand, **contact us anytime to arrange a group meeting** -
-we are always happy for an eager audience.
+to arrange a time.  On the other hand, **contact your most local
+(department) anytime to arrange a group meeting** - we are always
+happy for an eager audience.  Your local support will request all the
+other relevant parties to be there.
 
 The group meeting would happen whenever is most convenient for you -
-for example, during your regular group meetings.
+for example, during your regular group meetings.  **Please propose the
+best times for you**.  One hour is sufficient.
+
+**You don't need any particular preparation**.  If you do anything,
+think about what computational/data/software tools you use and what
+problems you have - you could have one or a few people tell about
+the typical workflows of the group.
 
 
 
@@ -31,8 +38,21 @@ Topics
 ------
 
 * Reminder of services available at Aalto and your department (short)
-* Latest changes or improvements (short))
+
+  * Computers and devices
+  * Computing: local servers, :doc:`Triton </triton/index>`, `CSC
+    <https://docs.csc.fi>`__, etc.  What do you usually use?
+  * Data storage: Department storage (project, archive), Triton
+    (scratch), cloud, any other needs?  What do you usually use?
+  * Cloud services
+  * Close specialist support teams
+
+    * Department
+    * :doc:`Science-IT </about/science-it>`
+    * :doc:`/rse/index`
+
+* Latest changes or improvements (short)
 * Feedback: How do you do your work now?  What works well?  What
   doesn't work well?  What do you need in the future?  **Tell us all
-  your complaints, without them, how can we work on the right
-  things?** (long)
+  your complaints**, because we can't work on the right things without
+  them. (long)

--- a/help/index.rst
+++ b/help/index.rst
@@ -71,6 +71,7 @@ doing, too.  Our main focus areas are
    garage
    community
    user-groups
+   group-meetings
 
 Website
 ~~~~~~~


### PR DESCRIPTION
- Add a new page for group meetings - the idea is that having some
  public text to link to makes sending group meeting emails easier.
- The topics are seeded from the CS group meetings wiki page, but most
  other text is somewhat new.
- Page created and linked in the help/ section, but I'm not sure if
  that's the right place.  I might do it in about/ instead?  Though
  user group meetings are in help/.
- Review:
  - Is it worth having a page on this?
  - Is the text useful?
  - Is it in the right section?
