### PR TITLE
Update main link to the software-design course to 2022

### DIFF
--- a/training/scip/index.rst
+++ b/training/scip/index.rst
@@ -38,7 +38,7 @@ deleted.  This series has existed since 2016.
   - :doc:`Linux Shell Scripting <shell-scripting>` (March 2021, `materials <https://aaltoscicomp.github.io/linux-shell/>`__)
   - :doc:`Hands-on data anonymization <data-anonymization-workshop>`  (April 2021, videos: `day1 <https://www.youtube.com/watch?v=kJGTLSLiuhI>`__, `day2 <https://www.youtube.com/watch?v=za8SYXX1wco>`__, `day3 <https://www.youtube.com/watch?v=oyToSTB1Jrc>`__, `dat4 <https://www.youtube.com/watch?v=9TE9nUjI8F0>`__)
   - `Code Refinery workshop <https://coderefinery.github.io/2021-05-10-workshop/>`__  (May 2021, `materials <https://coderefinery.github.io/2021-05-10-workshop/>`__, `videos <https://www.youtube.com/playlist?list=PLpLblYHCzJACm0Nz8ZxmdC6F8UuSYwWGQ>`__)
-  - :doc:`Software design for scientific computing <software-design>` (April 2021, `materials <https://github.com/susamerz/CDWAssignment>`__)
+  - :doc:`Software design for scientific computing <software-design-2021>` (April 2021, `materials <https://github.com/susamerz/CDWAssignment>`__)
   - :doc:`Matlab Advanced <matlab-advanced>` (May 2021, `materials <https://hackmd.io/@eglerean/MatlabAdvanced2021>`__)
   - Intro to Scientific Computing :doc:`part1
     <getting-started-with-scientific-computing>`, :doc:`part2 <summer-kickstart-2021>` (June 2021)

--- a/training/scip/software-design-2021.rst
+++ b/training/scip/software-design-2021.rst
@@ -1,0 +1,48 @@
+=====================================================
+April 2021 / Software design for scientific computing
+=====================================================
+
+Part of :doc:`Scientific Computing in Practice <index>` lecture series at Aalto University.
+
+**Audience:** employees and students, intermediate or advanced level
+in Python. For this course we also warmly invite those who already know everything there is to know about Python.
+
+**About the course:** Getting the desired end result is an important first step in writing your analysis script or program. But it is just the beginning of the journey to truly great software. In this course we set you on a path to thinking about the *design* of your code: how to make it obvious what the code does, that it is correct, efficient and elegant. As programmers, we are on this journey for our entire career. For example, we assume you know *how* to write a function in Python. In this course, we aim to teach you *which* function you should write.
+
+We will present some design guidelines and discuss them together. Then, we will all implement a simple, but not trivial, data analysis pipeline from the neuroimaging domain. Next, we will review each-others code based on the design guidelines and note things that were designed well and things that could be improved. Finally, we will re-work our code based on the feedback we received and things we learned from reading other people's code. Hopefully, you will end up with a pearl of great code that can serve as inspiration for the code you'll write from here on after.
+
+We expect that course participants are familiar with the Python programming language, along with the basic packages for scientific computing (NumPy/SciPy/Matplotlib/Pandas). To test your knowledge of these basics (and point you to relevant documentation to fill in any gaps), we have designed the `Gizmo challenge <https://github.com/wmvanvliet/gizmo>`_.
+
+**Lecturers:**
+
+- Susanne Merz, NBE, Aalto University
+- Marijn van Vliet, Science IT, Aalto University
+
+**Place:** Online, common Zoom link for all the sessions (Zoom link will be sent after registration).
+
+**Time, date (all times EET):**
+
++-------+-------------+---------------------------------------------------+
+|  Date |        Time | Event                                             |
++=======+=============+===================================================+
+| 19.04 | 12:00-14:00 | Theory session                                    |
++-------+-------------+---------------------------------------------------+
+| 26.04 | 10:00-14:00 | First review sessions (half hour slot per person) |
++-------+-------------+---------------------------------------------------+
+| 03.05 | 10:00-14:00 | Second round of review sessions (half hour slots) |
++-------+-------------+---------------------------------------------------+
+| 03.05 | 14:00-15:00 | Recap session and closing                         |
++-------+-------------+---------------------------------------------------+
+
+**Course material:** All course material can be found in this repository: `https://github.com/susamerz/CDWAssignment <https://github.com/susamerz/CDWAssignment>`__.
+
+**Cost:** Free of charge for FGCI consortium members including Aalto employees and students.
+
+**Registration:** currently closed.
+
+**Credits:** Credits are available for Aalto students and a course certificate can be provided on request for outsiders. Credits/certificate require full time participation and handling home work/assignments. Full course hours correspond roughly to 1 ECTS.
+
+**Setup instructions:** To access the online course you need to have access to Zoom, either through the Zoom client or through a browser. 
+To follow and participate in the workshop, we expect you to also have access to a Python installation with the basic scientific software stack (NumPy/SciPy/Matplotlib/Pandas, see `https://www.scipy.org <https://www.scipy.org>`_). We recommend an anaconda installation. You can refer to https://coderefinery.github.io/installation/python/ for installation instructions, ignoring the CodeRefinery specific parts. You will also need a working and configured git installation. Instructions at https://coderefinery.github.io/installation/git/.
+
+**Additional course info at:** susanne.merz -at- aalto.fi or marijn.vanvliet -at- aalto.fi

--- a/training/scip/software-design.rst
+++ b/training/scip/software-design.rst
@@ -1,5 +1,5 @@
 =====================================================
-April 2021 / Software design for scientific computing
+April 2022 / Software design for scientific computing
 =====================================================
 
 Part of :doc:`Scientific Computing in Practice <index>` lecture series at Aalto University.
@@ -9,14 +9,15 @@ in Python. For this course we also warmly invite those who already know everythi
 
 **About the course:** Getting the desired end result is an important first step in writing your analysis script or program. But it is just the beginning of the journey to truly great software. In this course we set you on a path to thinking about the *design* of your code: how to make it obvious what the code does, that it is correct, efficient and elegant. As programmers, we are on this journey for our entire career. For example, we assume you know *how* to write a function in Python. In this course, we aim to teach you *which* function you should write.
 
-We will present some design guidelines and discuss them together. Then, we will all implement a simple, but not trivial, data analysis pipeline from the neuroimaging domain. Next, we will review each-others code based on the design guidelines and note things that were designed well and things that could be improved. Finally, we will re-work our code based on the feedback we received and things we learned from reading other people's code. Hopefully, you will end up with a pearl of great code that can serve as inspiration for the code you'll write from here on after.
+We will present some design guidelines and discuss them together. Then, we will all implement a simple, but not trivial, data analysis pipeline. Next, we will review each-others code based on the design guidelines and note things that were designed well and things that could be improved. Finally, we will extend the goals of the analysis pipeline and re-work our code based on the feedback we received and things we learned from reading other people's code. Hopefully, you will end up with a pearl of great code that can serve as inspiration for the code you'll write from here on after.
 
-We expect that course participants are familiar with the Python programming language, along with the basic packages for scientific computing (NumPy/SciPy/Matplotlib/Pandas). To test your knowledge of these basics (and point you to relevant documentation to fill in any gaps), we have designed the `Gizmo challenge <https://github.com/wmvanvliet/gizmo>`_.
+We expect that course participants are familiar with the Python programming language, along with its basic packages. To test your knowledge of these basics (and point you to relevant documentation to fill in any gaps), we have designed the `Gizmo challenge <https://github.com/wmvanvliet/gizmo>`_.
 
 **Lecturers:**
 
 - Susanne Merz, NBE, Aalto University
-- Marijn van Vliet, Science IT, Aalto University
+- Thomas Pfau, Science IT, Aalto University
+- Marijn van Vliet, NBE, Aalto University
 
 **Place:** Online, common Zoom link for all the sessions (Zoom link will be sent after registration).
 
@@ -25,24 +26,24 @@ We expect that course participants are familiar with the Python programming lang
 +-------+-------------+---------------------------------------------------+
 |  Date |        Time | Event                                             |
 +=======+=============+===================================================+
-| 19.04 | 12:00-14:00 | Theory session                                    |
+| 25.04 | 12:00-14:00 | Theory session                                    |
 +-------+-------------+---------------------------------------------------+
-| 26.04 | 10:00-14:00 | First review sessions (half hour slot per person) |
+| 03.05 | 10:00-14:00 | First review sessions (half hour slot per person) |
 +-------+-------------+---------------------------------------------------+
-| 03.05 | 10:00-14:00 | Second round of review sessions (half hour slots) |
+| 09.05 | 10:00-14:00 | Second round of review sessions (half hour slots) |
 +-------+-------------+---------------------------------------------------+
-| 03.05 | 14:00-15:00 | Recap session and closing                         |
+| 09.05 | 14:00-15:00 | Recap session and closing                         |
 +-------+-------------+---------------------------------------------------+
 
 **Course material:** All course material can be found in this repository: `https://github.com/susamerz/CDWAssignment <https://github.com/susamerz/CDWAssignment>`__.
 
-**Cost:** Free of charge for FGCI consortium members including Aalto employees and students.
+**Cost:** Free of charge. Please note that we will need to limit the number of participants for this course, priority will be given to researchers from Aalto University.
 
-**Registration:** currently closed.
+**Registration:** You can register here https://forms.gle/GcbZpdfMPKuk5hME9
 
-**Credits:** Credits are available for Aalto students and a course certificate can be provided on request for outsiders. Credits/certificate require full time participation and handling home work/assignments. Full course hours correspond roughly to 1 ECTS.
+**Credits:** Credits are available for Aalto students and a course certificate can be provided on request for outsiders. Credits/certificate require full time participation and handling home work/assignments. Full course hours correspond roughly to 2 ECTS.
 
 **Setup instructions:** To access the online course you need to have access to Zoom, either through the Zoom client or through a browser. 
-To follow and participate in the workshop, we expect you to also have access to a Python installation with the basic scientific software stack (NumPy/SciPy/Matplotlib/Pandas, see `https://www.scipy.org <https://www.scipy.org>`_). We recommend an anaconda installation. You can refer to https://coderefinery.github.io/installation/python/ for installation instructions, ignoring the CodeRefinery specific parts. You will also need a working and configured git installation. Instructions at https://coderefinery.github.io/installation/git/.
+To follow and participate in the workshop, we expect you to also have access to a Python installation. While it will be possible to complete the exercises with only the basic pythons setup, we recommend an anaconda installation for ease of use. You can refer to https://coderefinery.github.io/installation/python/ for installation instructions, ignoring the CodeRefinery specific parts. You will also need a working and configured git installation. Instructions at https://coderefinery.github.io/installation/git/.
 
-**Additional course info at:** susanne.merz -at- aalto.fi or marijn.vanvliet -at- aalto.fi
+**Additional course info at:** susanne.merz -at- aalto.fi, marijn.vanvliet -at- aalto.fi or thomas.pfau -at- aalto.fi


### PR DESCRIPTION
https://scicomp.aalto.fi/training/scip/software-design/ still points to the 2021 course. This PR updates the link to 2022 version, and updates the archived version to point to software-design-2021.