### PR TITLE
Adding IdentityFile parameter for consistency

### DIFF
--- a/scicomp/ssh.rst
+++ b/scicomp/ssh.rst
@@ -181,7 +181,7 @@ Now, you can just do ``ssh triton`` or ``rsync
 triton:/m/cs/scratch/some_file .`` directly, by using the ``triton``
 alias.  Note that the Triton rule uses the name ``kosh`` which is
 defined in the first part of the file. The ``IdentityFile`` parameter is 
-necessary only if you have a none default key name (like the one indicated).
+necessary only if you have a non-default key name (like the one indicated).
 
 ..
   The purpose of this document is to describe how to use ssh such that

--- a/scicomp/ssh.rst
+++ b/scicomp/ssh.rst
@@ -167,17 +167,21 @@ This is placed in ``~/.ssh/config``::
     Host kosh
         User LOGIN_NAME
         Hostname kosh.aalto.fi
+        IdentityFile id_rsa_triton
 
     # Triton, via kosh
     Host triton
         User LOGIN_NAME
         Hostname triton.aalto.fi
-	ProxyJump kosh
+        ProxyJump kosh
+        IdentityFile id_rsa_triton
+
 
 Now, you can just do ``ssh triton`` or ``rsync
 triton:/m/cs/scratch/some_file .`` directly, by using the ``triton``
 alias.  Note that the Triton rule uses the name ``kosh`` which is
-defined in the first part of the file.
+defined in the first part of the file. The `IdentityFile` parameter is 
+necessary only if you have a none default key name (like the one indicated).
 
 ..
   The purpose of this document is to describe how to use ssh such that

--- a/scicomp/ssh.rst
+++ b/scicomp/ssh.rst
@@ -180,7 +180,7 @@ This is placed in ``~/.ssh/config``::
 Now, you can just do ``ssh triton`` or ``rsync
 triton:/m/cs/scratch/some_file .`` directly, by using the ``triton``
 alias.  Note that the Triton rule uses the name ``kosh`` which is
-defined in the first part of the file. The `IdentityFile` parameter is 
+defined in the first part of the file. The ``IdentityFile`` parameter is 
 necessary only if you have a none default key name (like the one indicated).
 
 ..


### PR DESCRIPTION
The current tutorial creates a non default name key, which needs to be indicated explicitly in the config. While this is mentioned before the Sample config file, it is missing in the config and I think the tutorial should be consistent, so that, if you follow all steps it works in the end. 