### PR TITLE
triton/apps: New pages for gcc and Intel compilers 

### DIFF
--- a/triton/apps/gcc.rst
+++ b/triton/apps/gcc.rst
@@ -17,7 +17,8 @@ Basic usage
 Available installations
 -----------------------
 
-Besides system compiler on login node, there are various GCC versions installed as modules.
+System compiler is installed only on the login node.
+Other versions of GCC are installed as modules.
 
 .. csv-table::
    :delim: |

--- a/triton/apps/gcc.rst
+++ b/triton/apps/gcc.rst
@@ -1,0 +1,46 @@
+===
+GCC
+===
+
+GNU Compiler Collection (GCC) is one of the most popular compilers for compiling
+C, C++ and Fortran programs.
+
+In Triton we have various GCC versions installed, but only some of them are
+actively supported.
+
+Basic usage
+-----------
+
+.. include:: ../examples/c/hello-world/hello_gcc.rst
+
+
+Available installations
+-----------------------
+
+Besides system compiler on login node, there are various GCC versions installed as modules.
+
+.. csv-table::
+   :delim: |
+   :header-rows: 1
+
+   GCC version | Module name
+   4.8.5       | none (on login node only)
+   8.4.0       | gcc/8.4.0
+   9.3.0       | gcc/9.3.0
+   11.2.0      | gcc/11.2.0
+
+Old installations
+-----------------
+
+These installations will work, but they are not actively updated.
+
+.. csv-table::
+   :delim: |
+   :header-rows: 1
+
+   GCC version                  | Module name
+   6.5.0                        | gcc/6.5.0
+   9.2.0                        | gcc/9.2.0
+   9.2.0 with (CUDA offloading) | gcc/9.2.0-cuda-nvptx
+
+Other old installations are not recommended.

--- a/triton/apps/gcc.rst
+++ b/triton/apps/gcc.rst
@@ -29,6 +29,9 @@ Besides system compiler on login node, there are various GCC versions installed 
    9.3.0       | gcc/9.3.0
    11.2.0      | gcc/11.2.0
 
+If you need a different version of GCC, please send a request through the :ref:`issue tracker <issuetracker>`.
+
+
 Old installations
 -----------------
 

--- a/triton/apps/intelcompilers.rst
+++ b/triton/apps/intelcompilers.rst
@@ -1,0 +1,62 @@
+===============
+Intel Compilers
+===============
+
+Intel provides their own compiler suite which is popular in HPC settings.
+This suite contains compilers for C (``icc``), C++ (``icpc``) and Fortran (``ifc``).
+
+Previously this suite was licensed, but nowadays Intel provides it for free as a part of
+their
+`oneAPI-program <https://www.intel.com/content/www/us/en/developer/tools/oneapi/overview.html>`_.
+This change has had an effect on many module names.
+
+In Triton we have various versions of Intel compiler suite installed, but only
+some of them are actively supported.
+
+Basic usage
+-----------
+
+Choosing a GCC for Intel compilers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Intel uses many tools from the GNU suite and thus requires a GCC for compilation.
+Thus it is recommended to load a GCC with
+
+.. code-block:: bash
+
+  module load gcc/8.4.0 intel-oneapi-compilers/2021.3.0
+
+See :ref:`GCC page <triton/apps/gcc>` for more information on available GCC compilers.
+
+.. include:: ../examples/c/hello-world/hello_icc.rst
+
+Current installations
+---------------------
+
+Besides system compiler on login node, there are various GCC versions installed as modules.
+
+.. csv-table::
+   :delim: |
+   :header-rows: 1
+
+   GCC version | Module
+   4.8.5       | none (on login node only)
+   8.4.0       | gcc/8.4.0
+   9.3.0       | gcc/9.3.0
+   11.2.0      | gcc/11.2.0
+
+Old installations
+-----------------
+
+These installations will work, but they are not actively updated.
+
+.. csv-table::
+   :delim: |
+   :header-rows: 1
+
+   GCC version                  | Module
+   6.5.0                        | gcc/6.5.0
+   9.2.0                        | gcc/9.2.0
+   9.2.0 with (CUDA offloading) | gcc/9.2.0-cuda-nvptx
+
+Other old installations are not recommended.

--- a/triton/apps/intelcompilers.rst
+++ b/triton/apps/intelcompilers.rst
@@ -19,31 +19,32 @@ Basic usage
 Choosing a GCC for Intel compilers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Intel uses many tools from the GNU suite and thus requires a GCC for compilation.
-Thus it is recommended to load a GCC with
+Intel uses many tools from the GCC suite and thus it is recommended to
+load a ``gcc``-module with it:
 
 .. code-block:: bash
 
-  module load gcc/8.4.0 intel-oneapi-compilers/2021.3.0
+  module load gcc/8.4.0 intel-oneapi-compilers/2021.4.0
 
-See :ref:`GCC page <triton/apps/gcc>` for more information on available GCC compilers.
+See :doc:`GCC page </triton/apps/gcc>` for more information on available GCC compilers.
 
 .. include:: ../examples/c/hello-world/hello_icc.rst
 
 Current installations
 ---------------------
 
-Besides system compiler on login node, there are various GCC versions installed as modules.
+There are various Intel compiler versions installed as modules.
 
 .. csv-table::
    :delim: |
    :header-rows: 1
 
-   GCC version | Module
-   4.8.5       | none (on login node only)
-   8.4.0       | gcc/8.4.0
-   9.3.0       | gcc/9.3.0
-   11.2.0      | gcc/11.2.0
+   Intel compiler version | Module
+   2021.2.0               | intel-oneapi-compilers/2021.2.0
+   2021.3.0               | intel-oneapi-compilers/2021.3.0
+   2021.4.0               | intel-oneapi-compilers/2021.4.0
+
+If you need a different version of these compilers, please send a request through the :ref:`issue tracker <issuetracker>`.
 
 Old installations
 -----------------
@@ -54,9 +55,10 @@ These installations will work, but they are not actively updated.
    :delim: |
    :header-rows: 1
 
-   GCC version                  | Module
-   6.5.0                        | gcc/6.5.0
-   9.2.0                        | gcc/9.2.0
-   9.2.0 with (CUDA offloading) | gcc/9.2.0-cuda-nvptx
+   Intel compiler version                        | Module
+   2019.3 with Intel MPI                         | intel-parallel-studio/cluster.2019.3-intelmpi
+   2019.3                                        | intel-parallel-studio/cluster.2019.3
+   2020.0 with Intel MPI                         | intel-parallel-studio/cluster.2020.0-intelmpi
+   2020.0                                        | intel-parallel-studio/cluster.2020.0
 
 Other old installations are not recommended.

--- a/triton/apps/intelcompilers.rst
+++ b/triton/apps/intelcompilers.rst
@@ -10,7 +10,7 @@ their
 `oneAPI-program <https://www.intel.com/content/www/us/en/developer/tools/oneapi/overview.html>`_.
 This change has had an effect on many module names.
 
-In Triton we have various versions of Intel compiler suite installed, but only
+In Triton we have various versions of the Intel compiler suite installed, but only
 some of them are actively supported.
 
 Basic usage

--- a/triton/examples/c/hello-world/hello.c
+++ b/triton/examples/c/hello-world/hello.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+int main()
+{
+   printf("Hello world.\n");
+   return 0;
+}

--- a/triton/examples/c/hello-world/hello_gcc.rst
+++ b/triton/examples/c/hello-world/hello_gcc.rst
@@ -1,0 +1,32 @@
+Hello world in C
+~~~~~~~~~~~~~~~~
+
+Let's consider the following Hello world-program 
+(:download:`hello.c</triton/examples/c/hello-world/hello.c>`)
+written in C.
+
+.. literalinclude:: /triton/examples/c/hello-world/hello.c
+	 :language: c
+
+
+After downloading it to a folder, we can compile it with GCC.
+
+First, let's load up a GCC module:
+
+.. code-block:: bash
+
+  module load gcc/8.4.0
+
+Secondly, let's compile the code:
+
+.. code-block:: bash
+
+  gcc -o hello hello.c
+
+Now we can run the program:
+
+.. code-block:: bash
+
+  ./hello
+
+This outputs the expected **Hello world**-string.

--- a/triton/examples/c/hello-world/hello_icc.rst
+++ b/triton/examples/c/hello-world/hello_icc.rst
@@ -1,0 +1,32 @@
+Hello world in C
+~~~~~~~~~~~~~~~~
+
+Let's consider the following Hello world-program 
+(:download:`hello.c</triton/examples/c/hello-world/hello.c>`)
+written in C.
+
+.. literalinclude:: /triton/examples/c/hello-world/hello.c
+	 :language: c
+
+
+After downloading it to a folder, we can compile it with Intel C compiler (``icc``).
+
+First, let's load up Intel compilers and a GCC module that ``icc`` will use in the background:
+
+.. code-block:: bash
+
+  module load gcc/8.4.0 intel-oneapi-compilers/2021.3.0
+
+Now let's compile the code:
+
+.. code-block:: bash
+
+  icc -o hello hello.c
+
+Now we can run the program:
+
+.. code-block:: bash
+
+  ./hello
+
+This outputs the expected **Hello world**-string.

--- a/triton/examples/c/hello-world/hello_icc.rst
+++ b/triton/examples/c/hello-world/hello_icc.rst
@@ -15,7 +15,7 @@ First, let's load up Intel compilers and a GCC module that ``icc`` will use in t
 
 .. code-block:: bash
 
-  module load gcc/8.4.0 intel-oneapi-compilers/2021.3.0
+  module load gcc/8.4.0 intel-oneapi-compilers/2021.4.0
 
 Now let's compile the code:
 


### PR DESCRIPTION
This PR contains new pages for gcc and intel compilers.