### PR TITLE
triton/apps/mpi: Adding a new page for MPI installations

### DIFF
--- a/triton/apps/mpi.rst
+++ b/triton/apps/mpi.rst
@@ -74,7 +74,7 @@ to compile the Hello world!-example by setting ``OMPI_MPICC``- and
 
   .. group-tab:: C
 
-    Intel C compiler is `icc`:
+    Intel C compiler is ``icc``:
 
     .. code-block:: bash
 
@@ -88,7 +88,7 @@ to compile the Hello world!-example by setting ``OMPI_MPICC``- and
 
   .. group-tab:: Fortran
 
-    Intel Fortran compiler is `ifort`:
+    Intel Fortran compiler is ``ifort``:
 
     .. code-block:: bash
 

--- a/triton/apps/mpi.rst
+++ b/triton/apps/mpi.rst
@@ -1,0 +1,103 @@
+===
+MPI
+===
+
+Message Passing Interface (MPI) is used in high-performance computing (HPC)
+clusters to facilitate big parallel jobs that utilize multiple compute nodes.
+
+MPI and Slurm
+*************
+
+For a tutorial on how to do Slurm reservations for MPI jobs, check out the
+:ref:`MPI section<parallel-mpi>` of the parallel computing-tutorial.
+
+Installed MPI versions
+**********************
+
+There are multiple installed MPI versions in the cluster, but due to updates
+to the underlying network and the operating system some older ones might not
+be functional.
+
+Therefore it is highly recommended to use the recommended and tested versions
+of MPI.
+
+Each MPI version will use some underlying compiler by default. Please check
+:ref:`here <mpi-changing-compilers>` for information on how to change the
+underlying compiler.
+
+.. csv-table::
+   :delim: |
+   :header-rows: 1
+
+   MPI provider | MPI version | GCC compiler | Module name
+   OpenMPI      | 4.0.5       | gcc/8.4.0    | openmpi/4.0.5
+
+.. include:: /triton/ref/mpi-warning.rst
+
+Usage
+*****
+
+Compiling and running an MPI Hello world-program
+------------------------------------------------
+
+.. include:: /triton/examples/mpi/hello.rst
+
+.. _mpi-changing-compilers:
+
+Overwriting default compiler of an MPI installation
+---------------------------------------------------
+
+Typically one should use the compiler that the MPI installation has been
+compiled with. Thus if you encounter a situation where you would like to
+use a different compiler, it might be best to ask the administrators to
+install a different version of MPI with a different compiler.
+
+However sometimes one can try to overwrite the default compiler. This will
+obviously be faster than installing newer MPI versions. However, if you
+encounter problems after switching the complier, you should not use it.
+
+Changing complier when using OpenMPI
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The procedure of changing compilers for OpenMPI is documented in
+`OpenMPI's FAQ <https://www.open-mpi.org/faq/?category=mpi-apps#override-wrappers-after-v1.0>`_.
+Environment variables such as ``OMPI_MPICC`` and ``OMPI_MPIFC`` can be
+set to overwrite the default compiler. See the article for full list
+of environment variables.
+
+For example, one could use an
+:doc:`Intel compiler </triton/apps/intelcompilers>`
+to compile the Hello world!-example by setting ``OMPI_MPICC``- and
+``OMPI_MPIFC``-environment variables.
+
+.. tabs::
+
+  .. group-tab:: C
+
+    Intel C compiler is `icc`:
+
+    .. code-block:: bash
+
+      module load gcc/8.4.0
+      module load openmpi/4.0.5
+      module load intel-oneapi-compilers/2021.4.0
+
+      export OMPI_MPICC=icc  # Overwrite the C compiler
+
+      mpicc    -O2 -g hello_mpi.c -o hello_mpi
+
+  .. group-tab:: Fortran
+
+    Intel Fortran compiler is `ifort`:
+
+    .. code-block:: bash
+
+      module load gcc/8.4.0
+      module load openmpi/4.0.5
+      module load intel-oneapi-compilers/2021.4.0
+
+      export OMPI_MPIFC=ifort  # Overwrite the Fortran compiler
+
+      mpicc    -O2 -g hello_mpi.c -o hello_mpi
+
+  .. group-tab:: 

--- a/triton/examples/mpi/hello.rst
+++ b/triton/examples/mpi/hello.rst
@@ -1,0 +1,63 @@
+The following example uses example codes stored in
+`the hpc-examples-repository <https://github.com/AaltoSciComp/hpc-examples>`_.
+You can get the repository with the following command::
+
+  git clone https://github.com/AaltoSciComp/hpc-examples/
+
+Loading module::
+
+  module load gcc/8.4.0      # GCC
+  module load openmpi/4.0.5  # OpenMPI
+
+Compiling the code:
+
+.. tabs::
+
+  .. group-tab:: C
+
+    C code is compiled with `mpicc`:
+
+    .. code-block:: bash
+
+      cd hpc-examples/hello_mpi/
+      mpicc    -O2 -g hello_mpi.c -o hello_mpi
+
+  .. group-tab:: Fortran
+
+    Fortran code is compiled with `mpifort`:
+
+    .. code-block:: bash
+
+      cd hpc-examples/hello_mpi_fortran/  # fortran
+      mpifort  -O2 -g hello_mpi_fortran.f90 -o hello_mpi_fortran # Fortran code
+
+For testing one might be interested in running the program with srun::
+
+  srun --time=00:05:00 --mem-per-cpu=200M --ntasks=4 ./hello_mpi
+
+For actual jobs this is obviously not recommended as any problem
+with the login node can crash the whole MPI job. Thus we'll want to run the
+program with a slurm script:
+
+.. code-block:: slurm
+
+  #!/bin/bash
+  #SBATCH --time=00:05:00      # takes 5 minutes all together
+  #SBATCH --mem-per-cpu=200M   # 200MB per process
+  #SBATCH --ntasks=4           # 4 processes
+  #SBATCH --constraint=avx     # set constraint for processor architecture
+
+  module load openmpi/4.0.5  # NOTE: should be the same as you used to compile the code
+  srun ./hello_mpi
+
+Triton has multiple architectures around (12, 20, 24, 40 CPU cores per node),
+even though SLURM optimizes resources usage and allocate CPUs within one node,
+which gives better performance for the app, it still makes sense to put
+constraints explicitly.
+
+.. important::
+
+   It is important to use ``srun`` when you launch your program.
+   This allows for the MPI libraries to obtain task placement information
+   (nodes, number of tasks per node etc.) from the slurm queue.
+

--- a/triton/examples/mpi/hello.rst
+++ b/triton/examples/mpi/hello.rst
@@ -15,7 +15,7 @@ Compiling the code:
 
   .. group-tab:: C
 
-    C code is compiled with `mpicc`:
+    C code is compiled with ``mpicc``:
 
     .. code-block:: bash
 
@@ -24,7 +24,7 @@ Compiling the code:
 
   .. group-tab:: Fortran
 
-    Fortran code is compiled with `mpifort`:
+    Fortran code is compiled with ``mpifort``:
 
     .. code-block:: bash
 

--- a/triton/examples/mpi/hello.rst
+++ b/triton/examples/mpi/hello.rst
@@ -45,15 +45,9 @@ program with a slurm script:
   #SBATCH --time=00:05:00      # takes 5 minutes all together
   #SBATCH --mem-per-cpu=200M   # 200MB per process
   #SBATCH --ntasks=4           # 4 processes
-  #SBATCH --constraint=avx     # set constraint for processor architecture
 
   module load openmpi/4.0.5  # NOTE: should be the same as you used to compile the code
   srun ./hello_mpi
-
-Triton has multiple architectures around (12, 20, 24, 40 CPU cores per node),
-even though SLURM optimizes resources usage and allocate CPUs within one node,
-which gives better performance for the app, it still makes sense to put
-constraints explicitly.
 
 .. important::
 

--- a/triton/examples/openmp/hello_omp/hello_omp.sh
+++ b/triton/examples/openmp/hello_omp/hello_omp.sh
@@ -4,7 +4,7 @@
 #SBATCH --cpus-per-task=4
 #SBATCH --output=hello_omp.out
 
-module load gcc/9.2.0
+module load gcc/8.4.0
 
 export OMP_PROC_BIND=true
 srun hello_omp

--- a/triton/examples/python/python_openmp/python_openmp.rst
+++ b/triton/examples/python/python_openmp/python_openmp.rst
@@ -16,7 +16,7 @@ The full code for the example is in
 One can run this example with ``srun``::
 
   wget https://raw.githubusercontent.com/AaltoSciComp/hpc-examples/master/python/python_openmp/python_openmp.py
-  module load anaconda
+  module load anaconda/2022-01
   export OMP_PROC_BIND=true
   srun --cpus-per-task=2 --mem=2G --time=00:15:00 python python_openmp.py
 

--- a/triton/examples/python/python_openmp/python_openmp.sh
+++ b/triton/examples/python/python_openmp/python_openmp.sh
@@ -5,7 +5,7 @@
 #SBATCH --mem-per-cpu=1G
 #SBATCH -o python_openmp.out
 
-module load anaconda/2020-03-tf2
+module load anaconda/2022-01
 
 export OMP_PROC_BIND=true
 

--- a/triton/examples/python_openmp.rst
+++ b/triton/examples/python_openmp.rst
@@ -10,7 +10,7 @@ Python OpenMP example
     #SBATCH --mem=2G
     #SBATCH -o parallel_Python.out
 
-    module load anaconda
+    module load anaconda/2022-01
 
     export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK
     srun -c $SLURM_CPUS_PER_TASK python parallel_Python.py

--- a/triton/ref/mpi-warning.rst
+++ b/triton/ref/mpi-warning.rst
@@ -1,0 +1,17 @@
+Some libraries/programs might have already existing requirement for a certain
+MPI version. If so, use that version or ask for administrators to create
+a version of the library with dependency on the MPI version you require.
+
+.. warning::
+
+   Different versions of MPI are not compatible with each other. Each
+   version of MPI will create code that will run correctly with only
+   that version of MPI. Thus if you create code with a certain version,
+   you will need to load the same version of the library when you are
+   running the code.
+
+   Also, the MPI libraries are usually linked to slurm and network
+   drivers. Thus, when slurm or driver versions are updated, some
+   older versions of MPI might break. If you're still using said
+   versions, let us know. If you're just starting a new project, it
+   is recommended to use our recommended MPI libraries.

--- a/triton/tut/parallel.rst
+++ b/triton/tut/parallel.rst
@@ -36,7 +36,6 @@ tutorials.
 .. highlight:: bash
 
 
-
 Parallel programming models
 ---------------------------
 
@@ -191,13 +190,13 @@ from HPC examples repository.
 Simple code compiling::
 
   wget https://raw.githubusercontent.com/AaltoSciComp/hpc-examples/master/openmp/hello_omp/hello_omp.c
-  module load gcc/9.2.0
+  module load gcc/8.4.0
   gcc -fopenmp -O2 -g hello_omp.c -o hello_omp
 
 Running an OpenMP code::
 
   export OMP_PROC_BIND=TRUE
-  module load gcc/9.2.0
+  module load gcc/8.4.0
   srun --cpus-per-task=4 --mem=500M --time=00:05:00 hello_omp
 
 The
@@ -214,94 +213,26 @@ you should load the same compiler that you used for compiling the code.
 .. include:: /triton/examples/python/python_openmp/python_openmp.rst
 
 
+.. _parallel-mpi:
+
 Message passing programs: MPI
 -----------------------------
 
 For compiling/running an MPI job one has to pick up one of the MPI library
 suites. There are various different MPI libraries that all implement the
-MPI standard. We recommend that you use either:
+MPI standard. We recommend that you use our OpenMPI installation
+(``openmpi/4.0.5``). For information on other installed versions, see the
+:doc:`MPI applications-page<../apps/mpi>`.
 
-  - OpenMPI (e.g. ``openmpi/3.1.4``)
-  - Intel's MPI (e.g. ``intel-parallel-studio/cluster.2020.0-intelmpi``)
-
-Some libraries/programs might have already existing requirement for a certain
-MPI version. If so, use that version or ask for administrators to create
-a version of the library with dependency on the MPI version you require.
-
-.. warning::
-
-   Different versions of MPI are not compatible with each other. Each
-   version of MPI will create code that will run correctly with only
-   that version of MPI. Thus if you create code with a certain version,
-   you will need to load the same version of the library when you are
-   running the code.
-
-   Also, the MPI libraries are usually linked to slurm and network
-   drivers. Thus, when slurm or driver versions are updated, some
-   older versions of MPI might break. If you're still using said
-   versions, let us know. If you're just starting a new project, it
-   is recommended to use our recommended MPI libraries.
+.. include:: /triton/ref/mpi-warning.rst
 
 For basic use of MPI programs, you will need to use the
 ``-n N``/``--ntasks=N``-option to specify the number of MPI workers.
 
-Running a typical MPI program
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Compiling and running an MPI Hello world-program
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following use ``hpc-examples`` from
-:ref:`the previous exercises <triton-tut-exercise-repo>`.  Get the
-code::
-
-  git clone https://github.com/AaltoSciComp/hpc-examples/
-  cd hpc-examples/hello_mpi/          # C
-  cd hpc-examples/hello_mpi_fortran/  # fortran
-
-Loading module::
-
-  # GCC + OpenMPI
-  module load gcc/9.2.0      # GCC
-  module load openmpi/3.1.4  # OpenMPI
-
-  # Intel compilers + Intel's MPI
-  module load intel-parallel-studio/cluster.2019.3-intelmpi
-
-Compiling the code (depending on module and language)::
-
-  # OpenMPI
-  mpicc    -O2 -g hello_mpi.c -o hello_mpi # C code
-  mpifort  -O2 -g hello_mpi_fortran.f90 -o hello_mpi_fortran # Fortran code
-
-  # Intel MPI
-  mpiicc   -O2 -g hello_mpi.c -o hello_mpi # C code
-  mpiifort -O2 -g hello_mpi_fortran.f90 -o hello_mpi_fortran # Fortran code
-
-Running the program with srun (for testing)::
-
-  srun --time=00:05:00 --mem-per-cpu=200M --ntasks=4 ./hello_mpi
-
-Running an MPI code in the batch mode:
-
-.. code-block:: slurm
-
-  #!/bin/bash
-  #SBATCH --time=00:05:00      # takes 5 minutes all together
-  #SBATCH --mem-per-cpu=200M   # 200MB per process
-  #SBATCH --ntasks=4           # 4 processes
-  #SBATCH --constraint=avx     # set constraint for processor architecture
-
-  module load openmpi/3.1.4  # NOTE: should be the same as you used to compile the code
-  srun ./hello_mpi
-
-Triton has multiple architectures around (12, 20, 24, 40 CPU cores per node),
-even though SLURM optimizes resources usage and allocate CPUs within one node,
-which gives better performance for the app, it still makes sense to put
-constraints explicitly.
-
-.. important::
-
-   It is important to use ``srun`` when you launch your program.
-   This allows for the MPI libraries to obtain task placement information
-   (nodes, number of tasks per node etc.) from the slurm queue.
+.. include:: /triton/examples/mpi/hello.rst
 
 Spreading MPI workers evenly
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -309,9 +240,9 @@ Spreading MPI workers evenly
 In many cases you might require more than one node during your job's runtime.
 
 When this is the case, it is usually recommended to split the number of
-workers somewhat evenly among the nodes. To do this, one can use
-``-N N``/``--nodes=N`` and ``--ntasks-per-node=n``. For example, the previous example
-could be written as:
+workers evenly among the nodes. To do this, one can use
+``-N N``/``--nodes=N`` and ``--ntasks-per-node=n``. For example, you could
+distribute the previously requested four tasks to two nodes with:
 
 .. code-block:: slurm
 
@@ -322,13 +253,50 @@ could be written as:
   #SBATCH --ntasks-per-node=2  # 2 processes per node * 2 nodes = 4 processes in total
   #SBATCH --constraint=avx     # set constraint for processor architecture
 
-  module load openmpi/3.1.4  # NOTE: should be the same as you used to compile the code
+  module load openmpi/4.0.5  # NOTE: should be the same as you used to compile the code
   srun ./hello_mpi
 
+
 This way the number of workers is distributed more evenly, which in turn
-reduces communication overhead between workers.
+reduces communication overhead between workers. The total number of tasks is
+``--nodes`` times the ``--ntasks-per-node``.
 
 
+Setting a constraint for a specific CPU architecture
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The number of CPUs/tasks one can specify for a single parallel job depends
+usually on the underlying algorithm. In many codes, such as many
+finite-difference codes, the workers are set in a grid-like structure. The user
+of said codes has then a choice of choosing the dimensions of the simulation
+grid aka. how many workers are in x-, y-, and z-dimensions.
+
+For best perfomance one should reserve half or full nodes when possible. In
+heterogeneous clusters this can be a bit more complicated as different CPUs
+can have different numbers of cores.
+
+In Triton CPU partitions there are machines with 24, 28 and 40 CPUs. See the
+list of :ref:`available nodes<hardware-list>` for more information.
+
+However, one can make the reservations easier by specifying a CPU architecture
+with ``--constraint=ARCHITECTURE``. This tells Slurm to look for nodes that
+satisfy a specific feature. To list available features, one can use
+``slurm features``.
+
+For example, one could limit the code to the Haswell-architecture with the
+following script:
+
+.. code-block:: slurm
+
+  #!/bin/bash
+  #SBATCH --time=00:05:00      # takes 5 minutes all together
+  #SBATCH --mem-per-cpu=200M   # 200MB per process
+  #SBATCH --nodes=1            # 1 node
+  #SBATCH --ntasks-per-node=24 # 24 processes as that is the number in the machine
+  #SBATCH --constraint=hsw     # set constraint for processor architecture
+
+  module load openmpi/4.0.5  # NOTE: should be the same as you used to compile the code
+  srun ./hello_mpi
 
 Monitoring performance
 ----------------------


### PR DESCRIPTION
This PR does the following:

- Adds a new page that tells about available MPI installations.
- Updates the parallel tutorial with new information.
- Updates multiple module names in examples.