### PR TITLE
triton/ref/slurm_status: Add the GPU utilization command

### DIFF
--- a/triton/ref/slurm_status.rst
+++ b/triton/ref/slurm_status.rst
@@ -8,6 +8,7 @@
    ``slurm cpus`` *PARTITION*               | list free CPUs in a partition
    ``slurm history`` *[1day,2hour,...]*     | Show status of recent jobs
    ``seff`` *JOBID*                         | Show percent of mem/CPU used in job
+   ``sacct -o comment -p -j`` *JOBID*       | Show GPU efficiency
    ``slurm j`` *JOBID*                      | Job details (only while running)
    ``slurm s`` ; ``slurm ss`` *PARTITION*   | Show status of all jobs
    ``sacct``                                | Full history information (advanced, needs args)


### PR DESCRIPTION
- This was missing from the Slurm list but is very useful.
