### PR TITLE
rkdarst/triton ref slurm gpu eff

### DIFF
--- a/triton/ref/slurm_status.rst
+++ b/triton/ref/slurm_status.rst
@@ -7,7 +7,7 @@
    ``slurm partitions``                     | Overview of partitions (A/I/O/T=active,idle,other,total)
    ``slurm cpus`` *PARTITION*               | list free CPUs in a partition
    ``slurm history`` *[1day,2hour,...]*     | Show status of recent jobs
-   ``seff`` *JOBID*                         | Show percent of mem/CPU used in job
+   ``seff`` *JOBID*                         | Show percent of mem/CPU used in job.  See :doc:`Monitoring <../tut/monitoring>`.
    ``sacct -o comment -p -j`` *JOBID*       | Show GPU efficiency
    ``slurm j`` *JOBID*                      | Job details (only while running)
    ``slurm s`` ; ``slurm ss`` *PARTITION*   | Show status of all jobs


### PR DESCRIPTION
- triton/ref/slurm_status: Add the GPU utilization command
- triton/ref/slurm_status: give link to monitoring section
