### PR TITLE
training/scip/workflows-2023: Add template page

### DIFF
--- a/training/scip/workflows-2023.rst
+++ b/training/scip/workflows-2023.rst
@@ -1,0 +1,13 @@
+Workflows
+=========
+
+In our :doc:`summer HPC kickstart <summer-kickstart-2022>` courses, we
+show the basic principles of using a cluster and other computing
+tools.  Yet there is still a long way from basic usage to the powerful
+workflows that people use in their science.  This course is designed
+to fill that gap by showing advanced real-life examples of how people
+actually do their science with computers.
+
+This course is expected in February 2023 but dates and exact topics
+are not yet.  If you are interested in helping out or you have
+requests for topics, please :doc:`get in touch <help>`.

--- a/training/scip/workflows-2023.rst
+++ b/training/scip/workflows-2023.rst
@@ -1,7 +1,7 @@
 Workflows
 =========
 
-In our :doc:`summer HPC kickstart <summer-kickstart-2022>` courses, we
+In our :doc:`summer HPC kickstart <kickstart-2022-summer>` courses, we
 show the basic principles of using a cluster and other computing
 tools.  Yet there is still a long way from basic usage to the powerful
 workflows that people use in their science.  This course is designed


### PR DESCRIPTION
- Add a page so we can start linking to it
- The course and page needs a better title than "Workflows", I think.
- We should make a registration page asap, even if we don't know the
  dates
- Review: small fixups but merge quickly to iterate.
