### PR TITLE
Adding OVERRIDE to doc

### DIFF
--- a/triton/apps/python-conda.rst
+++ b/triton/apps/python-conda.rst
@@ -265,6 +265,7 @@ reproducible.
 Creating more complex environments
 **********************************
 
+.. include:: /triton/examples/cuda/cuda_override_hint.rst
 
 Creating an environment with CUDA toolkit
 -----------------------------------------
@@ -288,6 +289,7 @@ In other cases one can use an environment file like this
 :download:`cuda-env.yml </triton/examples/cuda/cuda-env.yml>`:
 
 .. literalinclude:: /triton/examples/cuda/cuda-env.yml
+
 
 
 .. include:: /triton/examples/tensorflow/tensorflow_with_conda.rst

--- a/triton/apps/pytorch.rst
+++ b/triton/apps/pytorch.rst
@@ -25,9 +25,8 @@ Building your own environment with PyTorch
 
 If you need a PyTorch version different to the one supplied with anaconda we
 recommend installing your own anaconda environment as detailed `here </triton/apps/python-conda.rst>`_.
-If you want to use the GPUs, you will need to install a GPU enabled pytorch version
-in your environment. This can be done by explicitly requesting a GPU enabled 
-pytorch version in your environment file as detailed below.
+
+.. include:: /triton/examples/cuda/cuda_override_hint.rst
  
 .. include:: /triton/examples/pytorch/pytorch_with_conda.rst
 

--- a/triton/apps/tensorflow.rst
+++ b/triton/apps/tensorflow.rst
@@ -24,15 +24,8 @@ Installing via conda
 
 Have a look :doc:`here </triton/apps/python-conda>` for details on how to install 
 conda environments.
-While tensorflow GPU versions are no longer incompatible with systems where no 
-GPU is present they commonly come with a slightly slower performance on CPUs 
-compared to versions that are CPU optimized. Tensorflow addressed this issue by 
-being clever and installing a version optimized to the machine it is installed 
-on. This leads to an issue on clusters, where commonly the login node does not 
-have a CUDA enabled GPU installed. Therefore, is necessary to explicitly override 
-this selection mechanism as detailed `here <https://conda-forge.org/blog/posts/2021-11-03-tensorflow-gpu/#installation>`__
-, or to explicitly select a cuda enabled version of tensorflow in the environment
-file as explained below.
+
+.. include:: /triton/examples/cuda/cuda_override_hint.rst
 
 .. include:: /triton/examples/tensorflow/tensorflow_with_conda.rst
 

--- a/triton/examples/cuda/cuda_override_hint.rst
+++ b/triton/examples/cuda/cuda_override_hint.rst
@@ -1,0 +1,31 @@
+Creating an environment with packages requiring CUDA
+----------------------------------------------------
+
+Many tools check, whether the system has a cuda capable graphics card set up
+and will install non cuda enabled versions by default if none is found (as is 
+the case on the login node, where environments are normally built). This can 
+be overcome by loading cuda specific versions (as detailed below).
+It might however happen, that the environment creation process aborts with a 
+message similar to:
+
+.. code-block:: bash
+
+   nothing provides __cuda needed by tensorflow-2.9.1-cuda112py310he87a039_0
+  
+In this instance it might be necessary to override the CUDA settings used by 
+conda/mamba. 
+To do this, prefix your environment creation command with:
+
+.. code-block:: bash
+
+   CONDA_OVERRIDE_CUDA="11.2"
+
+as in:
+
+.. code-block:: bash
+
+   CONDA_OVERRIDE_CUDA="11.2" mamba env create -f cuda-env.yml
+
+This will allow conda to assume that the respective cuda libraries will be 
+present at a later point but skip those requirements during installation.
+

--- a/triton/examples/cuda/cuda_override_hint.rst
+++ b/triton/examples/cuda/cuda_override_hint.rst
@@ -14,13 +14,8 @@ message similar to:
   
 In this instance it might be necessary to override the CUDA settings used by 
 conda/mamba. 
-To do this, prefix your environment creation command with:
-
-.. code-block:: bash
-
-   CONDA_OVERRIDE_CUDA="11.2"
-
-as in:
+To do this, prefix your environment creation command with ``CONDA_OVERRIDE_CUDA=CUDAVERSION``, 
+where CUDAVERSION is the Cuda toolkit version you intend to use as in:
 
 .. code-block:: bash
 


### PR DESCRIPTION
Seems like there are several versions of e..g. tensorflow now, where simply specifying the cuda version is insufficient and you need to actively override the conda CUDA detection mechanism. 
Added this to the docs.