### PR TITLE
Add a quick reference section for conda

### DIFF
--- a/triton/apps/python-conda.rst
+++ b/triton/apps/python-conda.rst
@@ -11,6 +11,8 @@ and R packages.
 Quick usage guide
 *****************
 
+.. _conda-first-time-setup:
+
 First time setup
 ----------------
 

--- a/triton/ref/conda.rst
+++ b/triton/ref/conda.rst
@@ -1,0 +1,87 @@
+.. list-table::
+   :header-rows: 1
+
+   * * Command
+     * Description
+   * * ``module load miniconda``
+     * Load module that provides miniconda on Triton - recommended for
+       using ``conda`` for your own environments.
+   * * :ref:`conda-first-time-setup`
+     * See link for six commands to run once per user account on
+       Triton (to avoid filling up all space on your home directory).
+   * * .. code-block:: yaml
+
+         name: conda-example
+         channels:
+           - conda-forge
+         dependencies:
+           - numpy
+           - pandas
+     * Minimal ``environment.yml`` example.  By defining our requirements
+       in one place, our environment becomes reproducible and we can
+       solve problems by re-creating it.  "Dependencies" lists
+       packages that will be installed.
+   * * **Environment management:**
+     *
+   * * ``conda env create --file environment.yml``
+     * Create environment from yaml file.  Use ``-n NAME`` to set or
+       override the name from the .yml file.  Environments with ``-n``
+       are stored in ``conda config --show envs_dirs``.
+   * * ``source activate NAME``
+     * Activate environment of name NAME.  Note we use this and *not*
+       ``conda init``/``conda activate`` to avoid changing Python for your whole
+       account.
+   * * ``source deactivate``
+     * Deactivate conda from this session.
+   * * ``conda env list``
+     * List all environments.
+   * * ``conda env remove -n NAME``
+     * Remove the environment of that name.
+   * * **Package management:**
+     * Inside the activate environment
+   * * ``conda list``
+     * List packages in currently active environment.
+   * * ``conda install --freeze-installed --channel CHANNEL PACKAGE_NAME``
+     * Install packages in an environment with minimal changes to what
+       is already installed.  Usually you would want to go at add them
+       to environment.yml if it is a dependency.  Better: add to
+       environment.yml and then see next line.
+   * * ``conda env update --file environment.yml``
+     * Update an environment file based on environment.yml
+   * * ``conda env export``
+     * Export an environment.yml that describes the current
+       environment.  Add ``--no-builds`` to make it more portable
+       across operating systems.  Add ``--from-history`` to list only
+       what you have explicitly requested in the past.
+   * * ``conda search [--channel conda-forge] NAME``
+     * Search for a package.  List includes name, version, build
+       version (often including linked libraries like Python/CUDA), and
+       channel.
+   * * **Other:**
+     *
+   * * ``mamba ...``
+     * Use ``mamba`` instead of ``conda`` for faster operations.
+       ``mamba`` is a drop-in replacement.  It should be installed in
+       the environment.
+   * * ``conda clean -a``
+     * Clean up cached files to free up space (not environments or
+       packages in them).
+   * * ``CONDA_OVERRIDE_CUDA="11.2" conda ..``
+     * Used when making CUDA environment on login node (choose right
+       CUDA version for you). Used with ``... env create`` or
+       ``... install`` to indicate that CUDA will be available when
+       the program runs.
+   * * Channel ``conda-forge``
+
+       Package selection ``tensorflow=*=*cuda*``
+     * Package selection for tensorflow.  The first ``*`` can be
+       replaced with the Tensorflow version specification
+   * * Channels ``pytorch`` and ``conda-forge``
+
+       Package selection ``pytorch=*=*cuda*``
+     * Package selection for pytorch.  The first ``*`` can be replaced
+       with the pytorch version specification.
+   * * CUDA
+     * In channel conda-forge, automatically selected based on
+       software you need.  For manual compilation, package
+       ``cudatoolkit`` in conda-forge.

--- a/triton/ref/index.rst
+++ b/triton/ref/index.rst
@@ -99,6 +99,15 @@ See also: :doc:`../tut/gpu`.
 
 .. include:: gpu.rst
 
+Conda
+=====
+
+See also: :doc:`../apps/python-conda`
+
+.. include:: conda.rst
+
+
+
 Command line
 ============
 


### PR DESCRIPTION
- This is mostly based on the page python-conda (I read through it and
  extracted the commands), with a bit of my own knowledge
- Put all of the most important commands in one place.  Like most
  things in the quick reference, this isn't usually suitable for use
  unless you have read the main information.  But if you have, the
  will make doing it over and over again much faster.
- This could also be inserted into the python-conda page itself (via
  include, like we do on other tutorial pages).
- This is longer than most of the other quick reference sections, but
  I think it's worth having everything in one place.
- Review: worth a somewhat close read.  And is there anything from
  here that should go to python-conda?
