### PR TITLE
triton: Add description of account purposes

### DIFF
--- a/triton/accounts.rst
+++ b/triton/accounts.rst
@@ -19,10 +19,10 @@ request the account.
 
 A few prerequisites:
 
--  You must have valid Aalto account
--  You must accept :doc:`Triton usage
-   policies <usagepolicy>`, including the data and privacy
+-  You must :doc:`check the intended use cases and agree with the Triton
+   usage policies <usagepolicy>`, including the data and privacy
    policies.
+-  You must have valid Aalto account.
 -  Also tell us your department/school in your account creation
    request.
 -  You should have enough background to use Triton well, including
@@ -32,10 +32,17 @@ A few prerequisites:
    should know A ("Basics"), C ("Linux"), and D ("HPC") well.  Also
    see the :ref:`Triton tutorials <tutorials>`.
 
-Accounts are for:
+Accounts are for (:doc:`see details <usagepolicy>`):
 
 - Researchers (as in, affiliated with a research PI in any way).
   Please tell us who your supervisor is in your account request.
+
+  - If you are a student doing a course project which is essentially
+    research project (you are basically joining the research group),
+    you may use Triton for that project.  You should be clear about
+    this in your request, put your *research* supervisor (not course
+    instructor) as supervisor, and we'll verify.
+
 - Students coming to one of our :doc:`Scientific Computing in Practice
   courses </training/scip/index>` which uses Triton.  You will be specifically
   told if this is the case

--- a/triton/usagepolicy.rst
+++ b/triton/usagepolicy.rst
@@ -1,6 +1,35 @@
 Usage policies and legal
 ========================
 
+Triton intended use cases
+-------------------------
+
+Triton accounts should be used for scientific research (anything
+sponsored by a research PI that is aligned with Aalto's mission),
+including employed researchers, masters, PhD theses, and others in a
+department staff database. In practice, anyone with a researcher,
+employee (not TAs), or visitor job title gets an account made
+immediately after they accept the terms of use. For others, we ask
+their research supervisor for confirmation before making an account.
+
+If you have an account, exploring computing to learn new skills or
+test out new is OK if it doesn't use large amounts of resources.  We
+don't mind other employees using it for lightweight computing tasks or
+experimentation, but we can help you find the best place if it gets
+large.
+
+Common exceptions:
+
+* Undergraduate students doing projects which can't be considered
+  research should use resources for students.
+* Courses should generally not recommend Triton as a resource. Certain
+  courses with a special reason (e.g. HPC courses) may use it after
+  special agreement between the instructor and Triton staff.
+* Student projects which are research projects with a research PI may
+  use Triton.
+
+
+
 Acceptable Use Policy and Terms of Service
 ------------------------------------------
 


### PR DESCRIPTION
- As discussed in our chats and meetings, this adds the clarifications
  that we have found.
- Review: most text is copied from other places, but worth reading to
  check in detail.
