### PR TITLE
Conda/Python examples update

### DIFF
--- a/triton/apps/python-conda.rst
+++ b/triton/apps/python-conda.rst
@@ -109,7 +109,7 @@ Packages in ``environment.yml`` can have version constraints and version
 wildcards. One can also specify pip packages to install after conda-packages
 have been installed.
 
-For example, the following 
+For example, the following
 :download:`dependency-env.yml </triton/examples/conda/dependency-env.yml>`
 would install a numpy with version higher or equal
 than 1.10 using conda and scipy via pip:
@@ -264,16 +264,11 @@ One can also use the environment files to make the installation procedure more
 reproducible.
 
 
-Creating more complex environments
-**********************************
-
-.. include:: /triton/examples/cuda/cuda_override_hint.rst
-
 Creating an environment with CUDA toolkit
------------------------------------------
+*****************************************
 
 NVIDIA's `CUDA-toolkit <https://developer.nvidia.com/cuda-toolkit>`_ is
-critical for working with NVIDIA's GPUs. Many Python frameworks that work on
+needed for working with NVIDIA's GPUs. Many Python frameworks that work on
 GPUs need to have a supported CUDA toolkit installed.
 
 Conda is often used to provide the CUDA toolkit and additional libraries such
@@ -292,15 +287,28 @@ In other cases one can use an environment file like this
 
 .. literalinclude:: /triton/examples/cuda/cuda-env.yml
 
+.. _cuda_hint:
+
+.. include:: /triton/examples/cuda/cuda_override_hint.rst
 
 
 .. include:: /triton/examples/tensorflow/tensorflow_with_conda.rst
 
+If you encounter errors related to CUDA while creating the
+environment, do note :ref:`this hint <cuda_hint>` on overriding
+CUDA during installation.
+
+
 .. include:: /triton/examples/pytorch/pytorch_with_conda.rst
+
+If you encounter errors related to CUDA while creating the
+environment, do note :ref:`this hint <cuda_hint>` on overriding
+CUDA during installation.
+
 
 
 Installing numpy with Intel MKL enabled BLAS
---------------------------------------------
+********************************************
 
 `NumPy <https://numpy.org/>`_ and other mathematical libaries utilize BLAS
 (Basic Linear Algebra Subprograms) implementation for speeding up many
@@ -314,9 +322,9 @@ One can install this library as the default BLAS by specifying
 
 .. literalinclude:: /triton/examples/conda/mkl-env.yml
 
-
 Advanced usage
 **************
+
 
 Finding available packages
 --------------------------
@@ -373,7 +381,7 @@ The output looks something like this::
   url         : https://conda.anaconda.org/conda-forge/linux-64/tensorflow-2.8.1-cuda112py39h01bd6f0_0.tar.bz2
   md5         : 35716504c8ce6f685ae66a1d9b084fc7
   timestamp   : 2022-05-21 09:09:53 UTC
-  dependencies: 
+  dependencies:
     - __cuda
     - python >=3.9,<3.10.0a0
     - python_abi 3.9.* *_cp39
@@ -394,10 +402,10 @@ see the dependencies:
 
 Output looks something like this::
 
-   Name                     Version Build                 Channel             
+   Name                     Version Build                 Channel
   ─────────────────────────────────────────────────────────────────────────────
    tensorflow               2.8.1   cuda112py39h01bd6f0_0 conda-forge/linux-64
-   __cuda >>> NOT FOUND <<<                                                   
+   __cuda >>> NOT FOUND <<<
    python                   3.9.9   h62f1059_0_cpython    conda-forge/linux-64
    python_abi               3.9     2_cp39                conda-forge/linux-64
    tensorflow-base          2.8.1   cuda112py39he716a45_0 conda-forge/linux-64
@@ -405,7 +413,7 @@ Output looks something like this::
 
 One can also print the full dependency list with
 ``mamba repoquery depends --tree``. This will produce a really long output.
-  
+
 .. code-block:: bash
 
   mamba repoquery depends --channel conda-forge tensorflow=2.8.1=cuda112py39h01bd6f0_0

--- a/triton/apps/python.rst
+++ b/triton/apps/python.rst
@@ -355,14 +355,7 @@ users try this every now and then).
 Examples
 --------
 
-Running Python with internal parallelization (OpenMP)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-A simple parallel Python script using OpenMP. Both anaconda modules and
-optimized Python modules support OpenMP, but optimized versions are
-faster.
-
-.. include:: ../examples/python_openmp.rst
+.. include:: ../examples/python/python_openmp/python_openmp.rst
 
 
 Running MPI parallelized Python with mpi4py

--- a/triton/apps/python.rst
+++ b/triton/apps/python.rst
@@ -62,8 +62,7 @@ dependencies in there.
 Quickstart
 ----------
 
-Use ``module load anaconda`` (or ``module load anaconda2`` for Python 2) to get a
-modern Python.
+Use ``module load anaconda`` to get our Python installation.
 
 If you have simple needs, use :ref:`pip install --user
 <pip-install-user>` to install packages.  For complex needs, use

--- a/triton/apps/pytorch.rst
+++ b/triton/apps/pytorch.rst
@@ -14,11 +14,8 @@ If you plan on using NVIDIA's containers to run your model, please check
 the page about :doc:`nvidiacontainers`.
 
 The basic way to use PyTorch is via the Python in the ``anaconda`` module.
-If you're not using Tensorflow as well, you can pick either ``-tf1``-
-or ``-tf2``-version. If you're using Tensorflow as well, please check our
-:doc:`tensorflow` page.
-
 Don't load any additional CUDA modules, ``anaconda`` includes everything.
+
 
 Building your own environment with PyTorch
 ******************************************
@@ -26,9 +23,9 @@ Building your own environment with PyTorch
 If you need a PyTorch version different to the one supplied with anaconda we
 recommend installing your own anaconda environment as detailed `here </triton/apps/python-conda.rst>`_.
 
-.. include:: /triton/examples/cuda/cuda_override_hint.rst
- 
 .. include:: /triton/examples/pytorch/pytorch_with_conda.rst
+
+.. include:: /triton/examples/cuda/cuda_override_hint.rst
 
 
 Examples:

--- a/triton/apps/tensorflow.rst
+++ b/triton/apps/tensorflow.rst
@@ -1,7 +1,7 @@
 Tensorflow
 ==========
 
-:pagelastupdated: 2022-08-08
+:pagelastupdated: 2022-01-09
 
 .. highlight:: bash
 
@@ -11,13 +11,6 @@ Basic usage
 ***********
 
 First, check the tutorials up to and including :doc:`../tut/gpu`.
-
-If you plan on using NVIDIA's containers to run your model, please check
-the page about :doc:`nvidiacontainers`.
-
-We provide a module for gpu enabled tensorflow 2.6  which can be loaded by 
-``module load tensorflow``. If you need a newer tensorflow version, 
-we suggest you install it via your own conda environment (see the instructions below).
 
 Installing via conda
 ********************

--- a/triton/apps/tensorflow.rst
+++ b/triton/apps/tensorflow.rst
@@ -15,12 +15,13 @@ First, check the tutorials up to and including :doc:`../tut/gpu`.
 Installing via conda
 ********************
 
-Have a look :doc:`here </triton/apps/python-conda>` for details on how to install 
+Have a look :doc:`here </triton/apps/python-conda>` for details on how to install
 conda environments.
+
+.. include:: /triton/examples/tensorflow/tensorflow_with_conda.rst
 
 .. include:: /triton/examples/cuda/cuda_override_hint.rst
 
-.. include:: /triton/examples/tensorflow/tensorflow_with_conda.rst
 
 Examples:
 *********

--- a/triton/examples/conda/mkl-env.yml
+++ b/triton/examples/conda/mkl-env.yml
@@ -4,4 +4,3 @@ channels:
 dependencies:
   - blas * mkl
   - numpy
-  - pandas

--- a/triton/examples/cuda/cuda_override_hint.rst
+++ b/triton/examples/cuda/cuda_override_hint.rst
@@ -1,26 +1,30 @@
-Creating an environment with packages requiring CUDA
-----------------------------------------------------
+.. hint::
 
-Many tools check, whether the system has a cuda capable graphics card set up
-and will install non cuda enabled versions by default if none is found (as is 
-the case on the login node, where environments are normally built). This can 
-be overcome by loading cuda specific versions (as detailed below).
-It might however happen, that the environment creation process aborts with a 
-message similar to:
+    During installation conda will
+    `try to verify <https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-virtual.html>`_
+    what is the maximum version of CUDA installed graphics cards can support
+    and it will install non-CUDA enabled versions by default if none are found
+    (as is the case on the login node, where environments are normally built).
+    This can be usually overcome by setting explicitly that the packages should
+    be the CUDA-enabled ones. It might however happen, that the environment
+    creation process aborts with a message similar to:
 
-.. code-block:: bash
+    .. code-block:: bash
 
-   nothing provides __cuda needed by tensorflow-2.9.1-cuda112py310he87a039_0
-  
-In this instance it might be necessary to override the CUDA settings used by 
-conda/mamba. 
-To do this, prefix your environment creation command with ``CONDA_OVERRIDE_CUDA=CUDAVERSION``, 
-where CUDAVERSION is the Cuda toolkit version you intend to use as in:
+       nothing provides __cuda needed by tensorflow-2.9.1-cuda112py310he87a039_0
 
-.. code-block:: bash
+    In this instance it might be necessary to override the CUDA settings used by
+    conda/mamba.
+    To do this, prefix your environment creation command with ``CONDA_OVERRIDE_CUDA=CUDAVERSION``,
+    where CUDAVERSION is the CUDA toolkit version you intend to use as in:
 
-   CONDA_OVERRIDE_CUDA="11.2" mamba env create -f cuda-env.yml
+    .. code-block:: bash
 
-This will allow conda to assume that the respective cuda libraries will be 
-present at a later point but skip those requirements during installation.
+       CONDA_OVERRIDE_CUDA="11.2" mamba env create -f cuda-env.yml
 
+    This will allow conda to assume that the respective CUDA libraries will be
+    present at a later point and so it will skip those requirements during
+    installation.
+
+    For more information, see this
+    `helpful post in Conda-Forge's documentation <https://conda-forge.org/docs/user/tipsandtricks.html#installing-cuda-enabled-packages-like-tensorflow-and-pytorch>`_.

--- a/triton/examples/pytorch/pytorch-env.yml
+++ b/triton/examples/pytorch/pytorch-env.yml
@@ -1,6 +1,10 @@
 name: pytorch-env
 channels:
+  - nvidia
   - pytorch
   - conda-forge
 dependencies:
-  - pytorch=*=*cuda*
+  - pytorch
+  - pytorch-cuda=11.7
+  - torchvision
+  - torchaudio

--- a/triton/examples/pytorch/pytorch_with_conda.rst
+++ b/triton/examples/pytorch/pytorch_with_conda.rst
@@ -1,5 +1,5 @@
 Creating an environment with GPU enabled PyTorch
-------------------------------------------------
+************************************************
 
 To create an environment with GPU enabled PyTorch you can use an
 environment file like this
@@ -7,8 +7,8 @@ environment file like this
 
 .. literalinclude:: /triton/examples/pytorch/pytorch-env.yml
 
-Here we install the latest pytorch vesion from ``pytorch``-channel with an additional
-requirement that the build version of the ``pytorch``-package must contain
-a reference to a cuda toolkit. Additional packages required by pytorch
-are installed from ``conda-forge``-channel. For a specific version replace the 
-``=*=*cuda*`` with e.g. ``=1.12=*cuda*`` for version ``1.12``.
+Here we install the latest pytorch version from ``pytorch``-channel and
+the ``pytorch-cuda``-metapackage that makes certain that the
+
+Additional packages required by pytorch
+are installed from ``conda-forge``-channel.

--- a/triton/examples/tensorflow/tensorflow_with_conda.rst
+++ b/triton/examples/tensorflow/tensorflow_with_conda.rst
@@ -1,5 +1,5 @@
 Creating an environment with GPU enabled Tensorflow
----------------------------------------------------
+***************************************************
 
 To create an environment with GPU enabled Tensorflow you can use an
 environment file like this


### PR DESCRIPTION
Lots of changes to Conda/Python examples:

- Change headers for CUDA toolkit, PyTorch and Tensorflow installation sections so that they appear in sidebar.
- Made CUDA override hint a hint that can be included in various different locations. Included it in Conda, PyTorch and Tensorflow pages.
- Small changes to CUDA override hint. Added references to Conda and Conda-Forge docs.
- Fixed naming of "CUDA" to be consistent with the actual name.
- Removed mentions to old software from pytorch / tensorflow pages.
- Removed line-end whitespaces.
- Fix Python page to include the correct OpenMP example