### PR TITLE
At the top of pages, list the last edited date

### DIFF
--- a/_templates/breadcrumbs.html
+++ b/_templates/breadcrumbs.html
@@ -1,0 +1,14 @@
+{%- extends "!breadcrumbs.html" %}
+
+{% block breadcrumbs_aside %}
+<li class="wy-breadcrumbs-aside">
+  {%- if gitstamp and not 'gitstamp_ignore' in (meta or {}) %}
+     {%- if gitstamp < (meta['gitstamp_warn'] or gitstamp_warn) %}
+      <span class="last-updated">Last updated <abbr class="last-updated-date last-updated-old abbr" style="color: darkred" title="This page is not necessarily wrong but you might want to be careful about it - contact us if you see problems (link in the sidebar).">{{ gitstamp }}</abbr></span>
+     {% else %}
+      <span class="last-updated">Last updated <span class="last-updated-date">{{ gitstamp }}</span></span>
+     {% endif %}
+     (<a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/commits/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ page_source_suffix }}" class="fa history" title="GitHub file history">History</a>)
+  {%- endif %}
+
+{% endblock %}

--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -7,6 +7,7 @@
 <!-- Request improvements to this page -->
 <div class="report-improvement" style="width: 300px; padding-left: 10px; padding-right: 10px; padding-top: 1ex; margin-top: 1ex; border-top: 2px solid aliceblue; text-align: center; color: #d9d9d9; font-size: 90%">
 <a style="color: #d9d9d9;" title="This will open a Github issue (Github account required).  We recommend this public issue tracker so that everyone can take part in the improvements - don't worry, even small improvements are welcome." href="https://github.com/AaltoSciComp/scicomp-docs/issues/new?title=page {{pagename}}: [insert topic of improvement here]&body=[What is confusing, what to improve, etc.  It's OK to say the problem and we figure out the solution.]">Report a problem with this page</a>
+<a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode or "blob" }}/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ page_source_suffix }}" class="fa" style="color: #d9d9d9;" title="Source on GitHub">(Edit)</a>
 </div>
 
 <!-- Mastodon -->

--- a/conf.py
+++ b/conf.py
@@ -24,6 +24,8 @@ on_rtd = os.environ.get('READTHEDOCS') == 'True'
 
 # -- General configuration ------------------------------------------------
 
+html_context = { }
+
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.0'
 
@@ -70,7 +72,11 @@ ogp_custom_meta_tags = ['<meta property="twitter:creator" content="@SciCompAalto
 
 
 # Add timestamps from git
-gitstamp_fmt = "%d %b %Y"
+gitstamp_fmt = "%Y %b %d"
+# dates earlier than this are highlighted in red in the theme.  Only
+# years supported so far due to %b time format.  Can be overwritten by
+# `:gitstamp_warn_date` in page metadata.
+html_context['gitstamp_warn'] = '2022'
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -188,11 +194,12 @@ html_theme_options = {
     #'navigation_depth': 3,
     #'canonical_url': 'https://scicomp.aalto.fi/'
     }
-html_context = {'display_github': True,
-                'github_user': 'AaltoSciComp',
-                'github_repo': 'scicomp-docs',
-                'github_version': 'master/',
-               }
+html_context.update(
+    {'display_github': True,
+     'github_user': 'AaltoSciComp',
+     'github_repo': 'scicomp-docs',
+     'github_version': 'master/',
+    })
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []

--- a/index.rst
+++ b/index.rst
@@ -4,6 +4,7 @@
    contain the root `toctree` directive.
 
 :og:description: Documentation about scientific and data-intensive computing at Aalto and beyond. Targeted towards Aalto researchers, but has some useful information for everyone.
+:gitstamp_ignore:
 
 .. meta::
    :keywords: Aalto Scientific Computing, Aalto SciComp, ASC, High-performance computing, HPC, Scientific computing, scicomp, research software, Aalto Research Software Engineers, AaltoRSE, RSE, RSEng

--- a/triton/ref/index.rst
+++ b/triton/ref/index.rst
@@ -1,3 +1,5 @@
+:gitstamp_ignore:
+
 ======================
 Triton quick reference
 ======================


### PR DESCRIPTION
- Previously, this was in the footer of each site.
- Now, instead of "Edit or Github", it says "Last edited %Y %b %d",
  and if the page is edited before a configurable threshold, it will
  put the date in `darkred`.
- This doesn't solve unmaintained pages, but it provides a more clear
  indication to users for what is up to date or not.  I think that
  keeping everything up to date is almost impossible, so instead let's
  make it easier for users to understand what is recent and not.
- Review: check preview and see.
