### PR TITLE
rse/portfolio: Add version.aalto.fi script project

### DIFF
--- a/rse/portfolio.rst
+++ b/rse/portfolio.rst
@@ -134,3 +134,20 @@ A researcher had created a code in Python to control a physical
 measurement device.  This code could be useful to others, but had to
 be packaged and released.  Aalto RSE helped to clean and release the
 code.  Time spent: 1 day.  Time saved: 1 month.
+
+
+
+Aalto Gitlab improvements (M)
+-----------------------------
+
+Aalto University's Gitlab needed some scripting for management tasks.
+While not exactly in our scope, we were the logical team to take a
+look (as opposed to hiring outside consultants, especially since we
+could better fit in with an incremental development schedule and
+longer-term support).  We talked with the system owners, refined the
+tasks, understood GitLab documentation, created the necessary scripts
+and improvements, handed them off to the sysadmins for production, and
+helped to understand tasks which should be done at another level.
+Time spent: 1 week.  Benefit: improved service for Aalto University,
+significant cost savings.  This type of project would be available for
+other internal service teams, assuming availability.


### PR DESCRIPTION
- This as a reasonable example of an internal project, and might
  inspire other teams to contact us with similar types of projects.
