### PR TITLE
Update serial.rst: change --mem-per-cpu in example batch script to --mem, add --cpus-per-task

### DIFF
--- a/triton/tut/serial.rst
+++ b/triton/tut/serial.rst
@@ -18,7 +18,8 @@ Serial Jobs
 
 	#!/bin/bash -l
 	#SBATCH --time=01:00:00
-	#SBATCH --mem-per-cpu=1G
+	#SBATCH --cpus-per-task=2
+	#SBATCH --mem=4G
 
 	module load anaconda
 	python my_script.py


### PR DESCRIPTION
The example could use the more beginner friendly (easier to understand) --mem instead of --mem-per-cpu.

Also, the example could explicitly set the number of cpus with --cpus-per-task or the default value of cpus-per-task=1 should be mentioned.