### PR TITLE
Remove HTCondor

### DIFF
--- a/aalto/htcondor.rst
+++ b/aalto/htcondor.rst
@@ -1,3 +1,5 @@
+:nosearch:
+
 ========
 HTCondor
 ========
@@ -12,7 +14,6 @@ HTCondor
 
    HTCondor is no longer in active use at Aalto.  This page serves as
    historical reference information that may be useful for others.
-
 
 Introduction
 ------------

--- a/aalto/index.rst
+++ b/aalto/index.rst
@@ -21,7 +21,6 @@ for Research page
    jupyterhub
    remotejupyter
    paniikki
-   htcondor
    git
    python
    opensource

--- a/about/index.rst
+++ b/about/index.rst
@@ -87,10 +87,9 @@ Infiniband network, and ~150 NVIDIA GPUs for deep learning and artificial
 intelligence research.  We provide a :doc:`Jupyter Notebook </triton/apps/jupyter>` based interface
 to enable light computing with less initial knowledge required to make
 our services easily accessible to everyone.  Our team also works with
-the CS, NBE, and PHYS departments to provide :doc:`HTCondor
-</aalto/htcondor>` (high throughput
-computing), data storage, and a seamless computational research
-experience.  We maintain http://scicomp.aalto.fi, the central hub for
+the CS, NBE, and PHYS departments to provide data storage and a seamless
+computational research experience.
+We maintain http://scicomp.aalto.fi, the central hub for
 scientific computing instructions and have a continuous :doc:`training
 program </training/index>`, :doc:`Scientific Computing in Practice </news/index>`.
 

--- a/training/index.rst
+++ b/training/index.rst
@@ -18,7 +18,7 @@ consortium.
 Examples of topics covered at different lectures: HPC crash course,
 Triton kickstarts, Linux Shell, Parallel programming models: MPI and
 OpenMP, GPU computing, Python for scientists, Data analysis with R
-and/or Python, Matlab, HTCondor and many others.
+and/or Python, Matlab and many others.
 
 If you are interested in a re-run of our past courses or if you want 
 to suggest a new course, `please take this survey <https://link.webropol.com/s/scipod>`__.

--- a/triton/apps/matlab.rst
+++ b/triton/apps/matlab.rst
@@ -162,51 +162,6 @@ parallel\_Matlab3.m::
             end
     end
 
-Hints for Condor users
-----------------------
-
-The above example also works (even nicer way) for condor.
-
-**A wrapper script to execute matlab on the department workstation.**
-
-::
-
-    #!/bin/bash -l
-    # a wrapper to run Matlab with condor
-    block=$1
-    pointsPerBlock=10
-    totalBlocks=10
-    matlab -nojvm -r "run($block,$pointsPerBlock,$totalBlocks)"
-
-**Condor submission script**
-
-Condor actually contains ArrayJob functionality that makes the task
-easier. ::
-
-    ## Condor submit description (script) file for my_program.exe.
-    ## 1. Specify the [path and] name for the executable file...
-    Executable = run.sh
-    ## 2. Specify Condor execution environment.
-    Universe = vanilla
-    notify   = Error
-    ## 3. Specify remote execution machines running Linux (required)...
-    Requirements = ((OpSys == "Linux") || (OpSysName == "Ubuntu"))
-    ## 4. Define input files and arguments
-    #Input = stdin.txt.$(Process)
-    Arguments = $(Process)
-    ## 5. Define output/error/log files
-    Output = log/stdout.$(Process).txt
-    Error  = log/stderr.$(Process).txt
-    Log    = log/log.$(Process).txt
-    ## 6. Tell Condor which files need to be transferred and when.
-    Transfer_input_files = run.m
-    Transfer_output_files = output-$(Process).mat
-    Transfer_executable = true
-    Should_transfer_files = YES
-    When_to_transfer_output = ON_EXIT
-    ## 7. Add 10 copies of the job to the queue
-    Queue 10
-
 
 FAQ / troubleshooting
 ---------------------


### PR DESCRIPTION
This PR removes HTCondor from various pages. Old HTCondor-page  is left for now as some training materials refer to it.