### PR TITLE
Fix typo in pytorch_mnist.rst

### DIFF
--- a/triton/examples/pytorch/pytorch_mnist.rst
+++ b/triton/examples/pytorch/pytorch_mnist.rst
@@ -9,7 +9,7 @@ Let's run the MNIST example from
    :language: python
 
 The full code for the example is in
-:download:`tensorflow_mnist.py</triton/examples/pytorch/pytorch_mnist.py>`.
+:download:`pytorch_mnist.py</triton/examples/pytorch/pytorch_mnist.py>`.
 One can run this example with ``srun``::
 
   wget https://raw.githubusercontent.com/AaltoSciComp/scicomp-docs/master/triton/examples/pytorch/pytorch_mnist.py


### PR DESCRIPTION
Fix tensorflow/pytorch typo in file name