### PR TITLE
Moved "if you miss day1" infobar to practical information.

### DIFF
--- a/training/scip/kickstart-2023.rst
+++ b/training/scip/kickstart-2023.rst
@@ -73,6 +73,17 @@ students.
 
 **Additional course info at:** scip@aalto.fi
 
+.. admonition:: If you can't attend day 1 (Aalto CS Summer day)
+   :class: dropdown
+
+   Most of day 1 is good background information, but not strictly
+   required.  You *will* need the Triton connection set up before
+   day 1.  We recommend you look at the :doc:`connecting tutorial
+   </triton/tut/connecting>` and get this set up in advance (either by
+   talking to a colleague or our :doc:`daily garage </help/garage>`).
+   Then, try to watch the relevant videos Wednesday morning or Tuesday
+   evening.
+
 
 
 Other universities
@@ -274,18 +285,6 @@ takes some effort to get ready.  Browse these resources:
   <https://coderefinery.github.io/manuals/how-to-attend-stream/>`__,
   good to read in detail (ignore the CodeRefinery-specific parts).
 * `How to use HackMD to take answer questions and hold discussions <https://coderefinery.github.io/manuals/hackmd-mechanics/>`__.
-
-.. admonition:: If you can't attend day 1 (Aalto CS Summer day)
-   :class: dropdown
-
-   Most of day 1 is good background information, but not strictly
-   required.  You *will* need the Triton connection set up before
-   day 1.  We recommend you look at the :doc:`connecting tutorial
-   </triton/tut/connecting>` and get this set up in advance (either by
-   talking to a colleague or our :doc:`daily garage </help/garage>`).
-   Then, try to watch the relevant videos Wednesday morning or Tuesday
-   evening.
-
 
 
 Technical prerequisites


### PR DESCRIPTION
Since it's likely that a lot of people need this info due to scheduling, I moved it under practical information instead of being slightly buried under schedule.