### PR TITLE
speech2text landing page

### DIFF
--- a/triton/apps/speech2text.rst
+++ b/triton/apps/speech2text.rst
@@ -1,0 +1,11 @@
+speech2text: easy speech transcription
+======================================
+
+speech2text is a wrapper we have made around the `Whisper
+<https://openai.com/research/whisper/>`__ tool to make it easier to
+run for a wide audience.  Fundamentally, it's a wrapper around the
+command line tool + set of instructions for transferring data in a way
+that (hopefully) can't go too wrong.
+
+You can read the instructions here:
+https://aaltorse.github.io/speech2text/


### PR DESCRIPTION
- Mainly directs to the github pages site, but makes it searchable from aalto.fi