### PR TITLE
Fixing R example link

### DIFF
--- a/triton/examples/r/r_openmp.rst
+++ b/triton/examples/r/r_openmp.rst
@@ -6,6 +6,6 @@ R OpenMP Example
 .. literalinclude:: /triton/examples/r/r_openmp.sh
 
 The benchmark script is available
-`here <https://r.research.att.com/benchmarks/R-benchmark-25.R>`__
+`here <https://mac.r-project.org/benchmarks/R-benchmark-25.R>`__
 (more information about it is available `here
 page <https://www.r-bloggers.com/r-benchmark-for-high-performance-analytics-and-computing-i/>`__).


### PR DESCRIPTION
Updating the link to the R benchmark script, the old one is broken.