### PR TITLE
Fix ProxyJump with ssh-copy-id

### DIFF
--- a/scicomp/ssh.rst
+++ b/scicomp/ssh.rst
@@ -282,7 +282,7 @@ the file to Triton.
 	 ::
 
 	    $ ssh-copy-id -i ~/.ssh/id_ed25519.pub USER@kosh.aalto.fi
-	    $ ssh-copy-id -i ~/.ssh/id_ed25519.pub -J USER@kosh.aalto.fi USER@triton.aalto.fi
+	    $ ssh-copy-id -i ~/.ssh/id_ed25519.pub -o ProxyJump=USER@kosh.aalto.fi USER@triton.aalto.fi
 
       .. group-tab:: Windows with PowerShell
 


### PR DESCRIPTION
`ssh-copy-id` doesn't support ProxyJump or `-J` option directly. The only way is passing `-o` to use `ssh` options like ProxyJump.
This PR fix this issue for new users to follow the ssh guide easier.