### PR TITLE
update instructions for openconnect

### DIFF
--- a/aalto/remoteaccess.rst
+++ b/aalto/remoteaccess.rst
@@ -70,8 +70,9 @@ Below is some quick reference info.
 -  Aalto windows: Start → Search → AnyConnect
 -  Personal Linux laptops: Use OpenConnect. Configuration on Ubuntu:
    Networks → Add Connection → Cisco AnyConnect compatible VPN. →
-   ``vpn.aalto.fi``. Then connect and use Aalto username/password. Or from
-   command line: ``openconnect https://vpn.aalto.fi``
+   Set Gateway to ``vpn.aalto.fi`` and User Agent to ``AnyConnect''.
+   Then connect and use Aalto username/password. Or from the command
+   line: ``openconnect https://vpn.aalto.fi --useragent=AnyConnect``
 -  Personal mac: `use Cisco AnyConnect VPN
    Client <https://download.aalto.fi/staff/>`__
 -  personal windows: `use Cisco AnyConnect VPN

--- a/aalto/remoteaccess.rst
+++ b/aalto/remoteaccess.rst
@@ -72,7 +72,7 @@ Below is some quick reference info.
    Networks → Add Connection → Cisco AnyConnect compatible VPN. →
    Set Gateway to ``vpn.aalto.fi`` and User Agent to ``AnyConnect''.
    Then connect and use Aalto username/password. Or from the command
-   line: ``openconnect https://vpn.aalto.fi --useragent=AnyConnect``
+   line: ``openconnect https://vpn.aalto.fi --useragent=AnyConnect``.  This requires a new enough OpenConnect, at least Ubuntu 23.10 has it.
 -  Personal mac: `use Cisco AnyConnect VPN
    Client <https://download.aalto.fi/staff/>`__
 -  personal windows: `use Cisco AnyConnect VPN


### PR DESCRIPTION
Cisco VPN now requires User Agent to contain the word AnyConnect to work.

https://scicomp.zulip.cs.aalto.fi/#narrow/stream/4-general/topic/VPN.20connection.20problem/near/276672