### PR TITLE
triton/apps/jupyter: Fix instructions for R kernel through conda

### DIFF
--- a/triton/apps/jupyter.rst
+++ b/triton/apps/jupyter.rst
@@ -293,7 +293,7 @@ modules you need::
   $ Rscript -e "library(IRkernel); IRkernel::installspec(name='NAME', displayname='R 3.6.1')"
 
   ## Use envkernel to re-write, loading the R modules.
-  $ envkernel lmod --user --kernel-template=NAME --name=NAME r-irkernel/1.1-python3
+  $ envkernel conda  --user --kernel-template=NAME --name=NAME $CONDA_PREFIX
 
 
 Installing a different R version as a kernel


### PR DESCRIPTION
There's a differenec between:
- running python in an environment (without PATH set)
- setting PATH etc and then running python in the environment

envkernel (with the rigth options) does the second

The previous instructions tried to load Lmod but didn't do the second.
