### PR TITLE
Update openmpi version to 4.1.5

### DIFF
--- a/triton/apps/mpi.rst
+++ b/triton/apps/mpi.rst
@@ -29,8 +29,9 @@ underlying compiler.
    :delim: |
    :header-rows: 1
 
-   MPI provider | MPI version | GCC compiler | Module name
-   OpenMPI      | 4.0.5       | gcc/8.4.0    | openmpi/4.0.5
+   MPI provider | MPI version | GCC compiler | Module name   | Extra notes
+   OpenMPI      | 4.1.5       | gcc/11.3.0   | openmpi/4.1.5 |
+   OpenMPI      | 4.0.5       | gcc/8.4.0    | openmpi/4.0.5 | There are known issues with this version, we do not recommend using this for new compilations
 
 .. include:: /triton/ref/mpi-warning.rst
 
@@ -78,8 +79,8 @@ to compile the Hello world!-example by setting ``OMPI_MPICC``- and
 
     .. code-block:: bash
 
-      module load gcc/8.4.0
-      module load openmpi/4.0.5
+      module load gcc/11.3.0
+      module load openmpi/4.1.5
       module load intel-oneapi-compilers/2021.4.0
 
       export OMPI_MPICC=icc  # Overwrite the C compiler
@@ -92,8 +93,8 @@ to compile the Hello world!-example by setting ``OMPI_MPICC``- and
 
     .. code-block:: bash
 
-      module load gcc/8.4.0
-      module load openmpi/4.0.5
+      module load gcc/11.3.0
+      module load openmpi/4.1.5
       module load intel-oneapi-compilers/2021.4.0
 
       export OMPI_MPIFC=ifort  # Overwrite the Fortran compiler

--- a/triton/examples/lammps/build/build_basic.rst
+++ b/triton/examples/lammps/build/build_basic.rst
@@ -31,7 +31,7 @@ we'll be using the version 22Jun2022.
   cd build
 
   # Activate CMake and OpenMPI modules needed by LAMMPS
-  module load cmake gcc/8.4.0 openmpi/4.0.5
+  module load cmake gcc/11.3.0 openmpi/4.1.5
 
   # Configure LAMMPS packages and set install folder
   cmake ../cmake -D BUILD_MPI=yes -D BUILD_OMP=yes -D CMAKE_INSTALL_PREFIX=../../lammps-mpi-23Jun2022

--- a/triton/examples/lammps/build/build_most.rst
+++ b/triton/examples/lammps/build/build_most.rst
@@ -27,7 +27,7 @@ Below is an example that installs LAMMPS with "most packages"-collection enabled
   cd build
 
   # Activate CMake and OpenMPI modules needed by LAMMPS
-  module load cmake gcc/8.4.0 openmpi/4.0.5 fftw/3.3.10-openmpi-openmp openblas/0.3.17-openmp eigen/3.4.0 ffmpeg/4.3.2  voropp/0.4.6 zstd/1.5.0
+  module load cmake gcc/11.3.0 openmpi/4.1.5 fftw/3.3.10 openblas/0.3.23 eigen/3.4.0 ffmpeg/6.0  voropp/0.4.6 zstd/1.5.5
 
   # Configure LAMMPS packages and set install folder
   cmake ../cmake -C ../cmake/presets/most.cmake -D BUILD_MPI=yes -D BUILD_OMP=yes -D CMAKE_INSTALL_PREFIX=../../lammps-mpi-most-23Jun2022

--- a/triton/examples/lammps/indent/lammps_indent.sh
+++ b/triton/examples/lammps/indent/lammps_indent.sh
@@ -7,7 +7,7 @@
 
 
 # Load modules used for building the LAMMPS binary
-module load cmake gcc/8.4.0 openmpi/4.0.5 fftw/3.3.10-openmpi-openmp openblas/0.3.17-openmp eigen/3.4.0 ffmpeg/4.3.2  voropp/0.4.6 zstd/1.5.0
+module load cmake gcc/11.3.0 openmpi/4.1.5 fftw/3.3.10 openblas/0.3.23 eigen/3.4.0 ffmpeg/6.0  voropp/0.4.6 zstd/1.5.5
 
 # Set path to LAMMPS executable
 export PATH=$PATH:$PWD/../../../lammps-mpi-most-23Jun2022/bin

--- a/triton/examples/mpi/hello.rst
+++ b/triton/examples/mpi/hello.rst
@@ -6,8 +6,8 @@ You can get the repository with the following command::
 
 Loading module::
 
-  module load gcc/8.4.0      # GCC
-  module load openmpi/4.0.5  # OpenMPI
+  module load gcc/11.3.0      # GCC
+  module load openmpi/4.1.5  # OpenMPI
 
 Compiling the code:
 
@@ -46,7 +46,7 @@ program with a slurm script:
   #SBATCH --mem-per-cpu=200M   # 200MB per process
   #SBATCH --ntasks=4           # 4 processes
 
-  module load openmpi/4.0.5  # NOTE: should be the same as you used to compile the code
+  module load openmpi/4.1.5  # NOTE: should be the same as you used to compile the code
   srun ./hello_mpi
 
 .. important::

--- a/triton/tut/parallel-mpi.rst
+++ b/triton/tut/parallel-mpi.rst
@@ -82,7 +82,7 @@ Compiling a MPI program
 For compiling/running an MPI job one has to pick up one of the MPI library
 suites. There are various different MPI libraries that all implement the
 MPI standard. We recommend that you use our OpenMPI installation
-(``openmpi/4.0.5``). For information on other installed versions, see the
+(``openmpi/4.1.5``). For information on other installed versions, see the
 :doc:`MPI applications page<../apps/mpi>`.
 
 .. include:: /triton/ref/mpi-warning.rst
@@ -118,9 +118,9 @@ It estimates pi with Monte Carlo methods and
 can utilize multiple MPI tasks for calculating the trials.
 
 First off, we need to compile the program with a suitable OpenMPI version. Let's use the
-recommended version ``openmpi/4.0.5``::
+recommended version ``openmpi/4.1.5``::
 
-   $ module load openmpi/4.0.5
+   $ module load openmpi/4.1.5
 
    $ mpicc -o pi-mpi pi-mpi.c
 
@@ -143,7 +143,7 @@ Using a slurm script setting the requirements and loading the correct modules be
    #SBATCH --nodes=1
    #SBATCH --ntasks=2
 
-   module load openmpi/4.0.5
+   module load openmpi/4.1.5
 
    srun ./pi-mpi 1000000
 
@@ -201,7 +201,7 @@ following script:
   #SBATCH --ntasks-per-node=24 # 24 processes as that is the number in the machine
   #SBATCH --constraint=hsw     # set constraint for processor architecture
 
-  module load openmpi/4.0.5  # NOTE: should be the same as you used to compile the code
+  module load openmpi/4.1.5  # NOTE: should be the same as you used to compile the code
   srun ./pi-mpi 1000000
 
 Monitoring performance

--- a/triton/usage/singularity.rst
+++ b/triton/usage/singularity.rst
@@ -262,7 +262,7 @@ Examples
       directly launches the ```sss2```-executable. Each container can
       run multiple OpenMP threads of Serpent.
    #. The openMPI library (v. 4.0.3) shipping with Ubuntu 20.04 seems
-      to be compatible with the Triton module ``openmpi/4.0.5``
+      to be compatible with the Triton module ``openmpi/4.1.5``
    #. The Ubuntu MPI library binds all the threads to the same
       CPU. This is avoided by passing the parameter ``--bind-to none``
       to mpirun.


### PR DESCRIPTION
This PR updates OpenMPI version to 4.1.5 as there are problems in the 4.0.5 module.