### PR TITLE
Updating anaconda -> scicomp-python-env in triton documentation

### DIFF
--- a/aalto/remotejupyter.rst
+++ b/aalto/remotejupyter.rst
@@ -29,8 +29,8 @@ Aalto provides two “light computing” servers: ``brute.org.aalto.fi``, ``forc
 	# Create a session. I use tmux
 	tmux
 
-	# Load Anaconda
-	module load anaconda
+	# Load the Aalto Scicomp python environment
+	module load scicomp-python-env
 
 	# Create your env
 	conda create -n env-name python=3.6 jupyter

--- a/triton/apps/deeplearn.rst
+++ b/triton/apps/deeplearn.rst
@@ -10,4 +10,4 @@ Theano
 Installation
 ------------
 
-The recommended way of installing theano is with an anaconda environment.
+The recommended way of installing theano is with a conda environment.

--- a/triton/apps/gurobi.rst
+++ b/triton/apps/gurobi.rst
@@ -22,13 +22,13 @@ Gurobi with Python
    
    Unfortunately the python gurobi packages installed via pip and via conda come with
    two distinct package names ``gurobi`` for the anaconda package and ``gurobipy`` for 
-   the pip package. Normally, we install the guobi package in the anaconda environment, 
+   the pip package. Normally, we install the guobi package in the scicomp python environment, 
    but there are some anaconda modules which have the gurobipy package. So you might need
    to select the correct package.
 
-.. admonition:: License Files for older Anaconda modules
+.. admonition:: License Files for older modules
    
-   Older anaconda modules on Triton might not have the GRB_LICENSE_FILE environment variable set 
+   Older modules on Triton might not have the GRB_LICENSE_FILE environment variable set 
    properly, so you might need to point to it manually. To do so, you need to create a 
    ``gurobi.lic`` file in your home folder. The file should contain the following single line:
     
@@ -50,7 +50,7 @@ Gurobi with Python
 
 After setting the license, one can run, for example::
 
-   module load anaconda
+   module load scicomp-python-env
    python 
 
 And then run the following script
@@ -91,7 +91,7 @@ Gurobi with Julia
 For Julia there exists a package called
 `Gurobi.jl <https://github.com/jump-dev/Gurobi.jl>`_ that provides an interface
 to Gurobi. This package needs Gurobi C libraries so that it can run. The
-easiest way of obtaining these libraries is to load the ``anaconda``-module and
+easiest way of obtaining these libraries is to load the ``scicomp-python-env``-module and
 use the same libraries that the Python API uses.
 
 To install Gurobi.jl, one can use the following commands::

--- a/triton/apps/jupyter.rst
+++ b/triton/apps/jupyter.rst
@@ -391,7 +391,7 @@ it with this:
 Install your own non-Python kernels
 -----------------------------------
 * First, ``module load jupyterhub/live``.  This loads
-  the anaconda environment which contains all the server code and
+  the conda environment which contains all the server code and
   configuration.  (This step may not be needed for all kernels)
 * Follow the instructions you find for your kernel.  You may need to
   specify ``--user`` or some such to have it install in your user
@@ -436,8 +436,8 @@ Here are the steps necessary to do so:
      There are two main reasons for this approach: A) it makes your code more maintainable, since you don't need to modify 
      the code when changing parameters and B) you are less likely to use the wrong version of your code (and thus getting the wrong results).
 5. (Optional) Set up a conda environment. This is mainly necessary if you have multiple conda or pip installable packages that are 
-   required for your job and which are not part of the normal anaconda module. Try it via ``module load anaconda``. 
-   You can't install into the anaconda environment provided by the anaconda module and you should NOT use  ``pip install --user`` as it will bite you later (and can cause difficult to debug problems).
+   required for your job and which are not part of the normal Sc module. Try it via ``module load scicomp-python-env``. 
+   You can't install into the scicomp environment provided by the scicomp-python-env module and you should NOT use  ``pip install --user`` as it will bite you later (and can cause difficult to debug problems).
    If you need to set up your own environment follow :doc:`this guide </triton/apps/python-conda/>`
 6. Set up a slurm batch script in a file e.g. ``simple_python_gpu.sh``. You can do this either with ``nano simple_python_gpu.sh`` 
    (to save the file press ``ctrl+x``, type ``y`` to save the file and press ``Enter`` to accept the file name), or you can mount

--- a/triton/apps/keras.rst
+++ b/triton/apps/keras.rst
@@ -11,8 +11,8 @@ other things).
 Basic usage
 -----------
 
-Keras is available in the ``anaconda`` module and some other anaconda
-modules.  Run ``module spider anaconda`` to list available modules.
+Keras is available in the ``scicomp-python-env`` module and some other 
+modules.  Run ``module spider scicomp-python-env`` to list available modules.
 
 You probably want to learn how to run in the :doc:`GPU queues
 <../tut/gpu>`.  The other information in the :doc:`tensorflow
@@ -25,7 +25,7 @@ Example
 ::
 
    srun --gres=gpu:1 --pty bash
-   module load anaconda
+   module load scicomp-python-env
    python3
    >>> import keras
    Using TensorFlow backend.

--- a/triton/apps/python-conda.rst
+++ b/triton/apps/python-conda.rst
@@ -91,7 +91,7 @@ Some of the most popular channels are:
 
 - ``conda-forge``: An open-source channel with over 18k packages.
   Highly recommended for new environments. Most packages in
-  ``anaconda``-modules come from here.
+  ``scicomp-python-env``-modules come from here.
 - ``defaults``: A channel maintained by
   `Anaconda Inc. <https://www.anaconda.com>`_. Free for non-commercial use.
   Default for anaconda distribution.
@@ -237,7 +237,7 @@ When should you use conda?
 --------------------------
 
 If you need basic Python packages, you can use pre-installed
-``anaconda``-modules. See the :doc:`Python-page <python>` for
+``scicomp-python-env``-modules. See the :doc:`Python-page <python>` for
 more information.
 
 You should use conda when you need to create your own custom environment.

--- a/triton/apps/python.rst
+++ b/triton/apps/python.rst
@@ -25,12 +25,12 @@ Python distributions
      * How to install own packages
 
    * * I don't really care, I just want recent stuff and to not worry.
-     * Anaconda: ``module load`` :sub:`(sw-module-anaconda) *anaconda*`
+     * The python environment created by Aalto Scientific computing: ``module load`` :sub:`(sw-module-scicomp-python-env) *scicomp-python-env*`
      *
 
    * * Simple programs with common packages, not switching between
        Pythons often
-     * Anaconda: ``module load anaconda``
+     * Scicomp Environment: ``module load scicomp-python-env``
      * ``pip install --user``
 
    * * Your own conda environment
@@ -48,7 +48,7 @@ bundled togeter), PyPy (a just-in-time compiler,  which can be much faster for
 some use cases). Triton supports all of these.
 
 -  For general scientific/data science use, we suggest that you use
-   Anaconda. It comes with the most common scientific software included,
+   the environment created by us (``module load scicomp-python-env``). It comes with the most common scientific software included,
    and is reasonably optimized.
 -  There are many other "regular" CPython versions in the module system.
    These are compiled and optimized for Triton, and are highly
@@ -64,7 +64,7 @@ dependencies in there.
 Quickstart
 ----------
 
-Use ``module load anaconda`` to get our Python installation.
+Use ``module load scicomp-python-env`` to get our Python installation.
 
 If you have simple needs, use :ref:`pip install --user
 <pip-install-user>` to install packages.  For complex needs, use
@@ -129,21 +129,12 @@ and non-Python compiled software and libraries. It is also all open
 source, and is packaged nicely so that it can easily be installed on
 any major OS.
 
-To load anaconda, use the module system (you can also load specific
-versions):
+To load an environment based on anaconda and maintained by us, use the module
+system (you can also load specific versions):
 
 ::
 
-    $ module load anaconda     # python3
-    $ module load anaconda2    # python2
-
-.. note::
-
-   Before 2020, Python3 was via the ``anaconda3`` module (note the
-   ``3`` on the end).  That's still there, but in 2020 we completely
-   revised our Anaconda installation system, and dropped active
-   maintenance of Python 2.  All updates are in ``anaconda`` only in
-   the future.
+    $ module load scicomp-python-env     # python3
 
 Conda environments
 ~~~~~~~~~~~~~~~~~~
@@ -294,7 +285,7 @@ basic idea is that you have a *controller* and *engines*.  You have a
 *client* process which is actually running your own code.
 
 Preliminary notes: ipyparallel is installed in the
-anaconda{2,3}/latest modules.
+scicomp-python-env/latest module.
 
 Let's say that you are doing some basic interactive work:
 
@@ -364,8 +355,9 @@ Advanced users can see this `rosetta
 stone <https://conda.io/projects/conda/en/latest/commands.html#conda-vs-pip-vs-virtualenv-commands>`__
 for reference.
 
-On Triton we have added some packages on top of the Anaconda
-installation, so cloning the entire Anaconda environment to local conda
+On Triton we have added some packages on top of the Anaconda and make 
+it available as the scicomp-python-env module, so cloning the entire 
+Anaconda environment to local conda
 environment will not work (not a good idea in the first place but some
 users try this every now and then).
 

--- a/triton/apps/pytorch.rst
+++ b/triton/apps/pytorch.rst
@@ -13,15 +13,15 @@ First, check the tutorials up to and including :doc:`../tut/gpu`.
 If you plan on using NVIDIA's containers to run your model, please check
 the page about :doc:`nvidiacontainers`.
 
-The basic way to use PyTorch is via the Python in the ``anaconda`` module.
-Don't load any additional CUDA modules, ``anaconda`` includes everything.
+The basic way to use PyTorch is via the Python in the ``scicomp-python-env`` module.
+Don't load any additional CUDA modules, ``scicomp-python-env`` includes everything.
 
 
 Building your own environment with PyTorch
 ******************************************
 
-If you need a PyTorch version different to the one supplied with anaconda we
-recommend installing your own anaconda environment as detailed `here </triton/apps/python-conda.rst>`_.
+If you need a PyTorch version different to the one supplied with the scicomp python environment we
+recommend installing your own conda environment as detailed `here </triton/apps/python-conda.rst>`_.
 
 .. include:: /triton/examples/pytorch/pytorch_with_conda.rst
 

--- a/triton/apps/spyder.rst
+++ b/triton/apps/spyder.rst
@@ -6,7 +6,7 @@ Spyder is the Scientific PYthon Development
 EnviRonment:\ https://www.spyder-ide.org/
 
 On triton there are two modules that provide Spyder:
-- The basic anaconda module:  ``module load anaconda`` or
+- The basic scicomp environment module:  ``module load scicomp-python-env`` or
 - The neuroimaging environment module: ``module load neuroimaging``
 
 By loading either module you will get access to Spyder.

--- a/triton/examples/multilang/python/parallel.sh
+++ b/triton/examples/multilang/python/parallel.sh
@@ -4,6 +4,6 @@
 #SBATCH --cpus-per-task=4
 #SBATCH --output=ParallelOut
 
-module load anaconda # use the normal anaconda environment for python
+module load scicomp-python-env # use the normal scicomp environment for python
 srun python parallel.py
 

--- a/triton/examples/multilang/python/parallel_fun.sh
+++ b/triton/examples/multilang/python/parallel_fun.sh
@@ -4,6 +4,6 @@
 #SBATCH --cpus-per-task=4
 #SBATCH --output=ParallelOut
 
-module load anaconda # use the normal anaconda environment for python
+module load scicomp-python-env # use the normal scicomp environment for python
 srun python parallel_fun.py
 

--- a/triton/examples/multilang/python/serial.sh
+++ b/triton/examples/multilang/python/serial.sh
@@ -5,7 +5,7 @@
 #SBATCH --output=python_array_%a.out
 
 
-module load anaconda # use the normal anaconda environment for python
+module load scicomp-python-env # use the normal scicomp environment for python
 
 srun python serial.py
 

--- a/triton/examples/multilang/python/serial_grouped.sh
+++ b/triton/examples/multilang/python/serial_grouped.sh
@@ -5,7 +5,7 @@
 #SBATCH --output=python_array_%a.out
 
 
-module load anaconda # use the normal anaconda environment for python
+module load scicomp-python-env # use the normal scicomp environment for python
 
 # size of each batch
 BATCHSIZE=10

--- a/triton/examples/python/ipyparallel/ipyparallel.sh
+++ b/triton/examples/python/ipyparallel/ipyparallel.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #SBATCH --nodes=4
 
-module load anaconda
+module load scicomp-python-env
 set -x
 
 ipcontroller --ip="*" &

--- a/triton/examples/python/python_openmp/python_openmp.rst
+++ b/triton/examples/python/python_openmp/python_openmp.rst
@@ -16,7 +16,7 @@ The full code for the example is in
 One can run this example with ``srun``::
 
   wget https://raw.githubusercontent.com/AaltoSciComp/hpc-examples/master/python/python_openmp/python_openmp.py
-  module load anaconda/2022-01
+  module load scicomp-python-env
   export OMP_PROC_BIND=true
   srun --cpus-per-task=2 --mem=2G --time=00:15:00 python python_openmp.py
 

--- a/triton/examples/python/python_openmp/python_openmp.sh
+++ b/triton/examples/python/python_openmp/python_openmp.sh
@@ -5,7 +5,7 @@
 #SBATCH --mem-per-cpu=1G
 #SBATCH -o python_openmp.out
 
-module load anaconda/2022-01
+module load scicomp-python-env
 
 export OMP_PROC_BIND=true
 

--- a/triton/examples/python_openmp.rst
+++ b/triton/examples/python_openmp.rst
@@ -10,7 +10,7 @@ Python OpenMP example
     #SBATCH --mem=2G
     #SBATCH -o parallel_Python.out
 
-    module load anaconda/2022-01
+    module load scicomp-python-env
 
     export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK
     srun -c $SLURM_CPUS_PER_TASK python parallel_Python.py

--- a/triton/examples/pytorch/pytorch_mnist.rst
+++ b/triton/examples/pytorch/pytorch_mnist.rst
@@ -15,7 +15,7 @@ One can run this example with ``srun``:
 .. code-block:: console
 
   $ wget https://raw.githubusercontent.com/AaltoSciComp/scicomp-docs/master/triton/examples/pytorch/pytorch_mnist.py
-  $ module load anaconda
+  $ module load scicomp-python-env
   $ srun --time=00:15:00 --gres=gpu:1 python pytorch_mnist.py
 
 or with ``sbatch`` by submitting

--- a/triton/examples/pytorch/pytorch_mnist.sh
+++ b/triton/examples/pytorch/pytorch_mnist.sh
@@ -2,6 +2,6 @@
 #SBATCH --gres=gpu:1
 #SBATCH --time=00:15:00
 
-module load anaconda
+module load scicomp-python-env
 
 python pytorch_mnist.py

--- a/triton/examples/tensorflow/tensorflow_mnist.rst
+++ b/triton/examples/tensorflow/tensorflow_mnist.rst
@@ -15,7 +15,7 @@ One can run this example with ``srun``:
 .. code-block:: console
 
   $ wget https://raw.githubusercontent.com/AaltoSciComp/scicomp-docs/master/triton/examples/tensorflow/tensorflow_mnist.py
-  $ module load anaconda
+  $ module load scicomp-python-env
   $ srun --time=00:15:00 --gres=gpu:1 python tensorflow_mnist.py
 
 or with ``sbatch`` by submitting

--- a/triton/examples/tensorflow/tensorflow_mnist.sh
+++ b/triton/examples/tensorflow/tensorflow_mnist.sh
@@ -2,6 +2,6 @@
 #SBATCH --gres=gpu:1
 #SBATCH --time=00:15:00
 
-module load anaconda
+module load scicomp-python-env
 
 python tensorflow_mnist.py

--- a/triton/ref/condaactivate.rst
+++ b/triton/ref/condaactivate.rst
@@ -11,7 +11,7 @@
    all cases, no confusion if others don't.)
 
    - If you activate one environment from another, for example after
-     loading an anaconda module, do ``source activate ENV_NAME`` like
+     loading an miniconda module, do ``source activate ENV_NAME`` like
      shown above (conda installation in the environment not needed).
 
    - If you make your own standalone conda environments, install the

--- a/triton/tut/modules.rst
+++ b/triton/tut/modules.rst
@@ -49,20 +49,20 @@ software by default for every user.
 A module lets you adjust what software is available,
 and makes it easy to switch between different versions.
 
-As an example, let's inspect the ``anaconda`` module with ``module
-show anaconda``:
+As an example, let's inspect the ``triton_base_python`` module with ``module
+show scicomp-python-env``:
 
 .. highlight:: console
 
 .. code-block:: console
 
-    $ module show anaconda
+    $ module show scicomp-python-env
     ----------------------------------------------------------------------------
       /share/apps/anaconda-ci/fgci-centos7-anaconda/modules/anaconda/2023-01.lua:
     ----------------------------------------------------------------------------
-    whatis("Name : anaconda")
+    whatis("Name : scicomp-python-env")
     whatis("Version : 2023-01")
-    help([[This is an automatically created Anaconda installation.]])
+    help([[This is an automatically created Python environment installation.]])
     prepend_path("PATH","/share/apps/anaconda-ci/fgci-centos7-anaconda/software/anaconda/2023-01/2eea7963/bin")
     setenv("CONDA_PREFIX","/share/apps/anaconda-ci/fgci-centos7-anaconda/software/anaconda/2023-01/2eea7963")
     setenv("GUROBI_HOME","/share/apps/anaconda-ci/fgci-centos7-anaconda/software/anaconda/2023-01/2eea7963")
@@ -101,11 +101,11 @@ modules (if this doesn't work, use ``which``).::
   Python 3.6.8
 
 But you need a newer version of Python.  To this end, you can **load**
-the ``anaconda`` module using the ``module load anaconda`` command,
+the ``scicomp-python-env`` module using the ``module load scicomp-python-env`` command,
 that has a more up to date Python with lots of libraries already
 included::
 
-  $ module load anaconda
+  $ module load scicomp-python-env
   $ type python
   python3 is /share/apps/anaconda-ci/fgci-centos7-anaconda/software/anaconda/2023-01/2eea7963/bin/python3
   $ python -V
@@ -119,7 +119,7 @@ using the ``module list`` command::
 
   $ module list
   Currently Loaded Modules:
-    1) anaconda/2023-01
+    1) scicomp-python-env/2023-01
 
 .. note::
   The ``module load`` and ``module list`` commands can be abbreviated as ``ml``
@@ -130,10 +130,10 @@ modules::
 
   $ module purge
 
-Or explicitly unload the ``anaconda`` module by using the ``module
-unload anaconda`` command::
+Or explicitly unload the ``scicomp-python-env`` module by using the ``module
+unload scicomp-python-env`` command::
 
-  $ module unload anaconda
+  $ module unload scicomp-python-env
 
 You can load any number of modules in your open shell, your scripts,
 etc.  You could load modules in your ``~/.bash_profile``, but then it
@@ -145,14 +145,14 @@ regularly!
 Module versions
 ---------------
 
-What's the difference between ``module load anaconda`` and ``module load
-anaconda/2023-01``?
+What's the difference between ``module load scicomp-python-env`` and ``module load
+scicomp-python-env/X``?
 
-The first ``anaconda`` loads the version that Lmod assumes to
+The first ``scicomp-python-env`` loads the version that Lmod assumes to
 be the latest one - which might change someday!  Suddenly, things don't
 work anymore and you have to fix them.
 
-The second loading ``anaconda/2023-01`` loads that exact version,
+The second loading ``scicomp-python-env/2023-01`` loads that exact version,
 which won't change.  Once you want stability (possibly from day one!), it's
 usually a good idea to load specific version, so that your environment
 will stay the same until you are done.
@@ -318,10 +318,10 @@ to check your local documentation for what the equivalents are.
 
    .. solution::
 
-      Let's use anaconda as an example. To see all available versions of anaconda,
-      we can either use ``module avail anaconda`` or the better option
-      ``module spider anaconda``. Oldest version of anaconda is ``anaconda/2020-01-tf1``.
-      We can load it using ``module load anaconda/2020-01-tf1``
+      Let's use scicomp-python-env as an example. To see all available versions of scicomp-python-env,
+      we can either use ``module avail scicomp-python-env`` or the better option
+      ``module spider scicomp-python-env``. The oldest version of the module is ``scicomp-python-env/X``.
+      We can load it using ``module load scicomp-python-env/2020-01-tf1``
 
 .. exercise:: Modules-2: Modules and PATH
 
@@ -334,7 +334,7 @@ to check your local documentation for what the equivalents are.
    it looks up the command in ``PATH``
 
    * Run ``echo $PATH`` and ``type python``.
-   * ``module load anaconda``
+   * ``module load scicomp-python-env``
    * Re-run ``echo $PATH`` and ``type python``.  How does it change?
 
    .. solution::
@@ -349,7 +349,7 @@ to check your local documentation for what the equivalents are.
 
 	 python is /usr/bin/python
 
-      After ``module load anaconda``, ``type python`` should print something like
+      After ``module load scicomp-python-env``, ``type python`` should print something like
       ``/share/apps/anaconda-ci/fgci-centos7-anaconda/software/anaconda/2023-01/2eea7963/bin/python``
       and you should see the same path added to your PATH.
 


### PR DESCRIPTION
This is a PR that will update references to anaconda to scicomp-python-env.

NOTE: Please do not merge before Triton v3 is in production
NOTE2: This PR does NOT update references to anaconda in the non triton specific instructions of the doc, since those also refer to workstations etc. We should probably work towards harmonization here, i.e. having the workstations (and thus aalto linux) be set up to use a new module, otherwise we start getting out of sync.