### PR TITLE
triton: remove VDI as a connection recommendation

### DIFF
--- a/triton/ref/connecting.rst
+++ b/triton/ref/connecting.rst
@@ -32,12 +32,6 @@
        also use passwords (since 2023)
        <https://aaltoscicomp.github.io/blog/2023/ssh-keys-with-passwords/>`__
 
-   * * `VDI <https://www.aalto.fi/en/services/vdiaaltofi-how-to-use-aalto-virtual-desktop-infrastructure>`__
-     * "Virtual desktop interface", https://vdi.aalto.fi, from there you can ``ssh``
-       to Triton or access OOD.  `More info
-       <https://www.aalto.fi/en/services/vdiaaltofi-how-to-use-aalto-virtual-desktop-infrastructure>`__.
-     * Whole Internet
-
    * * :doc:`Open OnDemand </triton/usage/ood>`
      * https://ondemand.triton.aalto.fi, Web-based interface to the
        cluster. Also known as OOD. Includes shell access, GUI, data transfer, Jupyter and a number of GUI applications

--- a/triton/tut/connecting.rst
+++ b/triton/tut/connecting.rst
@@ -255,23 +255,6 @@ are plenty of tutorials.
 
 
 
-Connecting via the Virtual Desktop Interface
---------------------------------------------
-
-.. seealso::
-
-   `VDI instructions on aalto.fi <https://www.aalto.fi/en/services/vdiaaltofi-how-to-use-aalto-virtual-desktop-infrastructure>`__
-
-If you go to https://vdi.aalto.fi, you can access a cloud-based Aalto Linux
-workstation.  HTML access works from everywhere, or download the
-"VMWare Horizon Client" for a better connection.  Start a Ubuntu
-desktop (you get Aalto Ubuntu).  From there, you **have to use the
-normal Linux ssh instructions to connect to Triton** (via the Terminal
-application) using the instructions you see above: ``ssh
-triton.aalto.fi``.
-
-
-
 VSCode
 ------
 


### PR DESCRIPTION
- OOD now has graphics +
- It's still mentioned as a remote data access method which seems OK
- It's still mentioned in `triton/tut/interactive.rst` but that
  section needs revising later anyway
- review: automerge 3day if no other comments
