### PR TITLE
Add an icon for external links

### DIFF
--- a/_static/theme_overrides.css
+++ b/_static/theme_overrides.css
@@ -57,3 +57,12 @@ details {
 .scicomp-table-dense th, .scicomp-table-dense td {
     padding: 8px 8px !important;
 }
+
+
+/* Link icon.  See more: https://stackoverflow.com/q/1899772 */
+a.reference.external::after {
+    /* content: "\01F517\00FE0E"; /* Globe emoji (text presentation) */
+    /*content: "\002197\00FE0E"; /* Up right arrow (text presentation) */
+    content: " \002197\00FE0F"; /* Up right arrow (emoji presentation) */
+    font-size: 60%;
+}


### PR DESCRIPTION
- This uses the unicode up right arrow symbol.

- Unicode doesn't have an "external link icon" but up-right-arrow was
  suggested as a replacement.

- This works but the icon isn't distinguished as a separate thing from
  text, thus things such as speech to text would get messed up by it.
  Does this actually reduce accessibility more than it improves
  usability?

- A quick check didn't reveal how these should be tagged to not be
  read/the meaning be understood.
