### PR TITLE
data/requesting: Revise the templates for requesting storage space

### DIFF
--- a/data/requesting.rst
+++ b/data/requesting.rst
@@ -21,56 +21,50 @@ Requesting to be added to a group
    Aalto networks, over VPN, or remote desktop at
    https://vdi.aalto.fi, and it should be obvious.
 
-Send an email to the responsible contact (see above) and **CC the
-group owner or responsible person**, and include this information:
+Send an email to the responsible department/IT services email address (see above) and **CC the
+group owner or responsible person**.  An example message is below:
 
--  Group name that you request to join
--  copy and paste this statement, or something similar: "I am aware that
-   all data stored here is managed by the group's owner and have read
-   the data management policies."
--  Ask the group owner to reply with confirmation.
--  Do you need access to scratch or work? If so, you need a Triton
-   account and you can request it now. If you don't, you'll get
-   "input/output error" and be *very* confused.
--  Example:
-
-     Hi, I (account=omes1) would like to join the group ``myprof``.  I
+     Hi, I (account=omes1) would like to join the group ``coolproject``.  I
      am aware that all data stored here is managed by the group's
      owner and have read the data management policies.
-     ``$professor_name``, please reply confirming my addition.
+
+     I have cc:ed GROUP_MANAGER_NAME, who can reply with confirmation
+     of adding me to the group.
+
+Do you need access to Triton project scratch directories? If so, you
+need a Triton account and you should :doc:`request it separately </triton/accounts>`.
+
+
 
 Requesting a new group
 ----------------------
 
-Send an email to the responsible contact (see above) with the following information. Group
-owners should be long-term (e.g. professor level) staff.
+Send an email such as the below to the right contact address (mix and
+match to make it suit your needs).  Include whichever paragraphs are
+relevant to your needs.  The group owners should be long-term
+(e.g. professor level) staff, but it can be requested by someone else
+who cc:s the owner (please discuss some first):
 
--  Requested group name (you can check the name from the lists below)
--  Owner of data (prof or long-term staff member)
--  Other responsible people who can authorized adding new members to the
-   group. (they can reply and say "yes" when someone asks to join the
-   group.)
--  Who is responsible for data should you become unavailable (default:
-   supervisor who is probably head of department).
--  Initial members
--  Expiration time (default=max 2 years, extendable. max 5 years
-   archive). We will ping you for management/renewal then.
--  Which filesystems and what quota. (project, archive, scratch). See
-   the :doc:`the storage page <aalto-details>`.
--  Basic description of purpose of group.
--  Is there any confidential or personal data (see above for disclaimer).
--  Any other notes that CS-IT should enforce, for example check NDA
-   before giving access.
--  Example:
 
-       I would like to request a new group ``coolproject``. I am the
-       owner, but my postdoc Tiina Tekkari can also approve adding
-       members.  (Should I become unavailable, my colleague Anna
-       Algorithmi (also a professor here) can provide advice on what
-       to do with the data)
+       I would like to request a new project directory named
+       ``coolproject`` on the [Triton scratch / XXX department project
+       / Aalto teamwork] drive.
 
-       We would like 20GB on the ``project`` filesystem.
+       We would like 200GB of storage space on the [CS department
+       project / Triton scratch / etc.] filesystems
+
+
+       I am the owner, but my postdoc Tiina Tekkari can also approve
+       adding new members to the access group. / [Use this ] I am requesting this
+       on behalf of my supervisor, cc:ed.
+
+
+       [ Should I become unavailable, my colleague Anna Algorithmi
+       (also a professor here) can provide advice on what to do with
+       the data / Follow these special instructions: ... ]
+
+       The initial people who have access should be: LIST_OF_PEOPLE
 
        This is for our day to day work in algorithms development, we
-       don't expect anything too confidential.
-
+       don't expect anything surprising about this data.  There isn't
+       any personal data here.


### PR DESCRIPTION
- Remove the long intimidating checklists

- Instead, write the same info into free-form templates that are
  suitable for any department and also ITS storage spaces.  People are
  asked to read and adapt to their needs, which hopefully has less
  barrier.
