### PR TITLE
Fix Azure OpenAI API link

### DIFF
--- a/aalto/generative-ai-tools.rst
+++ b/aalto/generative-ai-tools.rst
@@ -73,7 +73,7 @@ of text inputs.
 
 
 * `Aalto can provide Azure OpenAI API access
-  <https://www.aalto.fi/en/services/faq-productised-ai-and-azure-openai>`__,
+  <https://www.aalto.fi/en/services/aalto-ai-apis>`__,
   which gives you access to the same models as ChatGPT.  This comes
   with a good data security agreement, and small usage can be provided
   for free.


### PR DESCRIPTION
The ITS page is confusing and hard to find.
The updated link has all the information (from how to request to API usage, costs, endpoints etc). The previous link doesn't provide the API information, just how to request.

(Although the structure of the ITS page is confusing, I think having this link is better).