### PR TITLE
Update Aalto Windows link

### DIFF
--- a/aalto/windows.rst
+++ b/aalto/windows.rst
@@ -8,7 +8,7 @@ where login is via Aalto accounts.  If you have a standalone laptop
 the most part you will access your data and Aalto resources via
 :doc:`remoteaccess`.
 
-More instructions: https://inside.aalto.fi/display/ITServices/Windows
+More instructions: https://www.aalto.fi/en/services/aalto-windows-quick-guide
 
 
 


### PR DESCRIPTION
inside.aalto.fi doesn't exist anymore, found a somewhat similar replacement for the link.