### PR TITLE
Remove the pytorch channel from the list of conda channels

### DIFF
--- a/triton/apps/python-conda.rst
+++ b/triton/apps/python-conda.rst
@@ -117,8 +117,6 @@ Some of the most popular channels are:
   due to licensing issues.  Default for anaconda distribution.
 - ``bioconda``: A community maintained channel of
   `bioinformatics packages <https://bioconda.github.io>`_.
-- ``pytorch``: Official channel for `PyTorch <https://pytorch.org/>`_, a
-  popular machine learning framework.
 
 One can have multiple channels defined like in the following example:
 


### PR DESCRIPTION
The pytorch channel is deprecated and pytorch can be installed from conda-forge + nvidia instead.