### PR TITLE
Add hardcoded name for apptainer-wrapper in 'module show' hint

### DIFF
--- a/triton/usage/singularity.rst
+++ b/triton/usage/singularity.rst
@@ -96,7 +96,7 @@ Some of the Triton modules automatically activate a Singularity image.
 On Triton, you just need to load the proper module.  This will set
 some environment variables and enable the use of
 ``apptainer_wrapper`` (to see how it works, check ``module show
-MODULE_NAME``).
+apptainer-wrapper``).
 
 While the image itself is read-only, remember that ``/home``, ``/m``,
 ``/scratch`` and ``/l`` etc. are not. If you edit/remove files in


### PR DESCRIPTION
A small detail that made a newcomer stumble: the module is named apptainer-wrapper, and the tool is apptainer_wrapper. Clear in hindsight, but would IMO make sense here to show the name of the module. Another possible hint towards the right convention would be to use `MODULE-NAME` instead of `MODULE_NAME`.